### PR TITLE
Introduce auto deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .tmp/
+build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 #Use the new container-based infrastructure
 sudo: false
-language: sourcepawn
+language: c++
 cache:
   directories:
     - .tmp
@@ -22,7 +22,7 @@ notifications:
 #Set the build environment
 env:
   global:
-    - secure="KYpwJLE/aquoy9pnPSdgYECy1G8t5AO1RRqNaJjqwLAhjoge5nHRzhZnEhcOC+8wi+dfXUr+Dp4OA8k1ZZVykNGc+HNLTF0COj4FVsSG+JogVGCIr0I0o/7NnxiTgRQ08jugNCIGYNtQhgY4F+FYz03DY93XwO0tNM8JjNM+8NBegYR9t/pdZv9iQHSz74AeFMfC1//7ZyP9CnjY40HIa76e7evqmkE1A0kzBnjQfpgK3bBYddDaowC3zh7J36iw7QOawe3MqhmtNGodjH/AjPFsCsr+xC8zqMiQURBw3e08x7d50FWI4+XAmxeW6E2WrB+RS1Q8j7+ot0tvNfOhpQLpOhr/xpsRTYEyj/o/OvPtDHlEpnkm1zKaEJojHLnVJVLy4ktnZbDslPnkrQezhMqFc4wazUkZgFX7ZovuZUr67RYX02buLcndkqdDhQL6EuqLRLElKfP3vIsn/dqNN3OMefMz/BORDwPOuvbXaG6JynFx2mCov3pRXe4Y+IIFgbxRoGDu0OjdF+BCXGaqvanYu+Fw5iSBJndFjMPZubexJF6z+4RkFR6B5SWCV1YbJn3W2ilyK2e6gvrme63MCvQGVuzqSIqKKSSRWkhHdzVNHD2sLJKkQ8n4C6byaUdWwiZhI9O6+r1vUE6fw+GTDcMQLjhS6KIIEFJtxNCbk2E="
+    - secure: "KYpwJLE/aquoy9pnPSdgYECy1G8t5AO1RRqNaJjqwLAhjoge5nHRzhZnEhcOC+8wi+dfXUr+Dp4OA8k1ZZVykNGc+HNLTF0COj4FVsSG+JogVGCIr0I0o/7NnxiTgRQ08jugNCIGYNtQhgY4F+FYz03DY93XwO0tNM8JjNM+8NBegYR9t/pdZv9iQHSz74AeFMfC1//7ZyP9CnjY40HIa76e7evqmkE1A0kzBnjQfpgK3bBYddDaowC3zh7J36iw7QOawe3MqhmtNGodjH/AjPFsCsr+xC8zqMiQURBw3e08x7d50FWI4+XAmxeW6E2WrB+RS1Q8j7+ot0tvNfOhpQLpOhr/xpsRTYEyj/o/OvPtDHlEpnkm1zKaEJojHLnVJVLy4ktnZbDslPnkrQezhMqFc4wazUkZgFX7ZovuZUr67RYX02buLcndkqdDhQL6EuqLRLElKfP3vIsn/dqNN3OMefMz/BORDwPOuvbXaG6JynFx2mCov3pRXe4Y+IIFgbxRoGDu0OjdF+BCXGaqvanYu+Fw5iSBJndFjMPZubexJF6z+4RkFR6B5SWCV1YbJn3W2ilyK2e6gvrme63MCvQGVuzqSIqKKSSRWkhHdzVNHD2sLJKkQ8n4C6byaUdWwiZhI9O6+r1vUE6fw+GTDcMQLjhS6KIIEFJtxNCbk2E="
   matrix:
     - SOURCEMOD=stable
     - SOURCEMOD=dev
@@ -35,3 +35,13 @@ matrix:
 #And compile!
 script:
   - make compile-$SOURCEMOD
+
+after_success:
+  - |
+      if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
+        if [ "$SOURCEMOD" = "stable" ]; then
+          # because `make compile` was already done before,
+          # we only need to pack the build directory and deploy
+          make pack deploy
+        fi
+      fi

--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,13 @@ compile-stable:
 
 compile-dev:
 	./build_scripts/compile.sh -v --sourcemod 1.8.0-5868
+
+pack:
+	rm -fr ./build && mkdir ./build && cp -r ./updater ./build
+
+deploy:
+	@./build_scripts/deploy.sh -v \
+		--dir=build \
+		--repo=github.com/stickz/Redstone \
+		--token=${GH_TOKEN} \
+		--branch=build

--- a/README.md
+++ b/README.md
@@ -20,3 +20,15 @@ https://sm.alliedmods.net/new-api/
 # Compile plugins
 
 Run `make` to compile `addons/sourcemod/scripting/*.sp` files using latest stable build of SourceMod or `make compile-dev` to compile using latest dev build.
+
+# Deployment
+
+If you have write access to this repo then following command will compile and
+deploy all the files required by server to the `build` branch upstream:
+
+```
+GH_TOKEN=<your token>; make compile pack deploy
+```
+
+You won't likely need to do this manually though because Travis CI does
+that automatically each time `master` branch changes.

--- a/build_scripts/deploy.sh
+++ b/build_scripts/deploy.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env sh
+
+# set command line switches defaults
+verbose=false
+
+# process command line switches
+while [ $# -gt 0 ]
+do
+  case "$1" in
+    -v)  verbose=true;;
+    --repo=*) repo=`echo $1 | sed -e 's/^[^=]*=//g'`;;
+    --token=*) token=`echo $1 | sed -e 's/^[^=]*=//g'`;;
+    --branch=*) branch=`echo $1 | sed -e 's/^[^=]*=//g'`;;
+    --dir=*) dir=`echo $1 | sed -e 's/^[^=]*=//g'`;;
+    --)  shift; break;;
+    -*)
+      echo >&2 "usage: $0 [-v]
+                          [--repo github.com/owner/repo]
+                          [--token OAuth token]
+                          [--dir directory to deploy]
+                          [--branch remote branch]"
+      exit 1;;
+    *)  break;; # terminate while loop
+    esac
+    shift
+done
+
+if [ -z ${repo+x} ] || [ "$repo" = "" ]; then
+  echo "Error: No repo is specified. Please specify one in --repo= argument"
+  exit 1
+fi
+
+if [ "$verbose" = true ]; then
+  echo "- Provided repo: $repo"
+fi
+
+if [ -z ${dir+x} ] || [ "$dir" = "" ]; then
+  echo "Error: No directory to deploy is specified. Please specify one in --dir= argument"
+  exit 1
+fi
+
+if [ "$verbose" = true ]; then
+  echo "- Provided directory: $dir"
+fi
+
+if [ -z ${token+x} ] || [ "$token" = "" ]; then
+  echo "Error: No Github OAuth token is specified. Please specify one in --token= argument"
+  exit 1
+fi
+
+if [ -z ${branch+x} ] || [ "$branch" = "" ]; then
+  echo "Error: No branch is specified. Please specified one in --branch= argument"
+  exit 1
+fi
+
+if [ "$verbose" = true ]; then
+  echo "- Provided branch: $branch"
+fi
+
+# Detect OS and exit if OS is not supported
+OS="`uname`"
+case $OS in
+  'Linux')
+    OS='Linux'
+    if [ "$verbose" = true ]; then
+      echo "- Detected Linux"
+    fi
+    ;;
+  'Darwin') 
+    OS='Mac'
+    if [ "$verbose" = true ]; then
+      echo "- Detected OS X"
+    fi
+    ;;
+  *)
+    echo "Only Linux and OS X are supported"
+    exit 1
+    ;;
+esac
+
+# Get directory path of this script
+if [ "$OS" = "Mac" ]; then
+  SCRIPTDIR=$(cd "$(dirname "$0")"; pwd)
+elif [ "$OS" = "Linux" ]; then
+  SCRIPTPATH=$(readlink -f "$0")
+  SCRIPTDIR=$(dirname "$SCRIPTPATH")
+fi
+
+# Get project ROOT directory
+ROOTDIR=$(dirname "$SCRIPTDIR")
+
+BUILDDIR="$ROOTDIR/$dir"
+
+cd $BUILDDIR
+git init
+git config user.name "Travis-CI"
+git config user.email "travis@example.com"
+git add .
+git commit -m "Build Redstone server"
+git push --force --quiet "https://${token}@${repo}" master:${branch} > /dev/null 2>&1
+rm -fr .git
+
+if [ "$verbose" = true ]; then
+  echo "- Deployed $dir to branch $branch on $repo"
+fi


### PR DESCRIPTION
In continue to #29 

- Instruct Travis CI to deploy compiled plugins (with stable version of SDK)
  to `build` branch every time `master` branch is modified. Pull requests
  don't trigger this action.

  `$ GH_TOKEN=<your token> make compile pack deploy` is what is done behind the
  scenes

- Using `./build/` directory for builds (ignored by git)

- Only `./updated/` directory is deployed