### PR TITLE
Optimize travis build time by not waiting for dev compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,10 @@ env:
     - SOURCEMOD=stable
     - SOURCEMOD=dev
     
-# Allow dev build to fail
 matrix:
+  # Mark build as finished as soon as stable compilation is completed
+  fast_finish: true
+  # Allow dev build to fail
   allow_failures:
     - env: SOURCEMOD=dev
 


### PR DESCRIPTION
Since `dev` and `stable` compilations were separated and `dev` compilation is allowed to fail, Travis can mark build as finished as soon as `stable` compilation is completed.

After this PR is merged, Travis build should be ~2 times faster than before.