### PR TITLE
Simplify Travis CI deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,17 +37,17 @@ matrix:
 git:
   depth: 9999999
 
-
 #And compile!
 script:
   - make build-$SOURCEMOD
 
-after_success:
-  - |
-      if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
-        if [ "$SOURCEMOD" = "stable" ]; then
-          # because `make build` was already done before,
-          # we only need to run deploy task
-          make deploy
-        fi
-      fi
+deploy:
+  # don't remove files generated during the "build" task
+  skip_cleanup: true
+  # use custom shell scripting to deploy (we deploy to `build` branch)
+  provider: script
+  script: make deploy
+  # only run this when master branch is modified and only for stable build
+  on:
+    branch: master
+    condition: $SOURCEMOD = "stable"


### PR DESCRIPTION
- Use Travis `deploy` directive instead of `after_success`

  `deploy` is more suitable as it's definition is more readable
  in `.travis.yml` configuration file + it doesn't run on PR
  and forks by default