### PR TITLE
Simplify Travis CI deployment (2nd try)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ notifications:
 
 #Set the build environment
 env:
-  global:
-    - secure: "KYpwJLE/aquoy9pnPSdgYECy1G8t5AO1RRqNaJjqwLAhjoge5nHRzhZnEhcOC+8wi+dfXUr+Dp4OA8k1ZZVykNGc+HNLTF0COj4FVsSG+JogVGCIr0I0o/7NnxiTgRQ08jugNCIGYNtQhgY4F+FYz03DY93XwO0tNM8JjNM+8NBegYR9t/pdZv9iQHSz74AeFMfC1//7ZyP9CnjY40HIa76e7evqmkE1A0kzBnjQfpgK3bBYddDaowC3zh7J36iw7QOawe3MqhmtNGodjH/AjPFsCsr+xC8zqMiQURBw3e08x7d50FWI4+XAmxeW6E2WrB+RS1Q8j7+ot0tvNfOhpQLpOhr/xpsRTYEyj/o/OvPtDHlEpnkm1zKaEJojHLnVJVLy4ktnZbDslPnkrQezhMqFc4wazUkZgFX7ZovuZUr67RYX02buLcndkqdDhQL6EuqLRLElKfP3vIsn/dqNN3OMefMz/BORDwPOuvbXaG6JynFx2mCov3pRXe4Y+IIFgbxRoGDu0OjdF+BCXGaqvanYu+Fw5iSBJndFjMPZubexJF6z+4RkFR6B5SWCV1YbJn3W2ilyK2e6gvrme63MCvQGVuzqSIqKKSSRWkhHdzVNHD2sLJKkQ8n4C6byaUdWwiZhI9O6+r1vUE6fw+GTDcMQLjhS6KIIEFJtxNCbk2E="
   matrix:
     - SOURCEMOD=stable
     - SOURCEMOD=dev
@@ -37,17 +35,17 @@ matrix:
 git:
   depth: 9999999
 
-
 #And compile!
 script:
   - make build-$SOURCEMOD
 
-after_success:
-  - |
-      if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
-        if [ "$SOURCEMOD" = "stable" ]; then
-          # because `make build` was already done before,
-          # we only need to run deploy task
-          make deploy
-        fi
-      fi
+deploy:
+  # don't remove files generated during the "build" task
+  skip_cleanup: true
+  # use custom shell scripting to deploy (we deploy to `build` branch)
+  provider: script
+  script: make deploy
+  # only run this when master branch is modified and only for stable build
+  on:
+    branch: master
+    condition: $SOURCEMOD = "stable"

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,6 @@ build-dev:
 deploy:
 	@./build_scripts/deploy.sh -v \
 		--dir=build \
-		--repo=github.com/stickz/Redstone \
+		--repo=github.com/stickz/Redstone.git \
 		--token=${GH_TOKEN} \
 		--branch=build

--- a/build_scripts/deploy.sh
+++ b/build_scripts/deploy.sh
@@ -98,8 +98,14 @@ git config user.email "travis@example.com"
 git add .
 git commit -m "Build Redstone server"
 git push --force --quiet "https://${token}@${repo}" master:${branch} > /dev/null 2>&1
+RETVAL=$?
 rm -fr .git
 
-if [ "$verbose" = true ]; then
-  echo "- Deployed $dir to branch $branch on $repo"
+if test $RETVAL -gt 0; then
+  echo "Error: failed to push $dir to branch $branch on $repo"
+  exit $RETVAL
+else
+  if [ "$verbose" = true ]; then
+    echo "- Deployed $dir to branch $branch on $repo"
+  fi
 fi


### PR DESCRIPTION
Fixed the issues with #59 

- Use Travis `deploy` directive instead of `after_success`

  `deploy` is more suitable as it's definition is more readable
  in `.travis.yml` configuration file + it doesn't run on PR
  and forks by default

- Add `.git` extension to repo URL. According to my tests, git command
  within Travis CI failed to find repository without it

- Print error & fail build in Travis CI if deployment fails

- Remove encrypted `GH_TOKEN` environment variable from code and keep it in
  Travis CI repo settings instead.

Please insert your GitHub OAuth token inside Travis CI settings before merging this.