### PR TITLE
Improve UT printouts

### DIFF
--- a/addons/sourcemod/scripting/nd_universal_translator.sp
+++ b/addons/sourcemod/scripting/nd_universal_translator.sp
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <sourcemod>
 #include <nd_stocks>
 #include <nd_com_eng>
+#include <colors>
 
 // Rebuild plugin
 public Plugin myinfo =
@@ -37,9 +38,9 @@ public Plugin myinfo =
 
 /* Create Defines */
 #define LANGUAGE_COUNT 		44
-#define MESSAGE_COLOUR		"\x05"
-#define TAG_COLOUR		"\x04"
-#define CHAT_PREFIX		"\x05[xG]"
+#define MESSAGE_COLOUR		"{olive}"
+#define TAG_COLOUR		"{lightgreen}"
+#define CHAT_PREFIX		"{olive}[xG]"
 
 /* Include First Abstraction Layer */ 
 #include "ndpc/stock_functions.sp"

--- a/addons/sourcemod/scripting/nd_universal_translator.sp
+++ b/addons/sourcemod/scripting/nd_universal_translator.sp
@@ -42,6 +42,11 @@ public Plugin myinfo =
 #define TAG_COLOUR		"{lightgreen}"
 #define CHAT_PREFIX		"{olive}[xG]"
 
+char tColour[2][] = {
+	"{blue}",
+	"{red}"
+};
+
 /* Include First Abstraction Layer */ 
 #include "ndpc/stock_functions.sp"
 #include "ndpc/reg_functions.sp"

--- a/addons/sourcemod/scripting/ndpc/features/commander_lang.sp
+++ b/addons/sourcemod/scripting/ndpc/features/commander_lang.sp
@@ -23,14 +23,14 @@ public Action CMD_PrintCLang(int client, int args)
 	int team = GetClientTeam(client);
 	if (team != TEAM_CONSORT && team != TEAM_EMPIRE)
 	{
-		PrintToChat(client, "%s%t", CHAT_PREFIX, "Not On Team");
+		CPrintToChat(client, "%s%t", CHAT_PREFIX, "Not On Team");
 		return Plugin_Handled;	
 	}
 	
 	int commander = ND_GetCommanderOnTeam(team);
 	if (commander == NO_COMMANDER)
 	{
-		PrintToChat(client, "%s%t", CHAT_PREFIX, "No Team Commander");
+		CPrintToChat(client, "%s%t", CHAT_PREFIX, "No Team Commander");
 		return Plugin_Handled;
 	}
 	
@@ -62,7 +62,7 @@ void PrintCLangToTeam(int team, const char[] langName)
 	{
 		if (IsOnTeam(client, team))
 		{
-			PrintToChat(client, "%s%t", MESSAGE_COLOUR, "Commander Language", langName);  
+			CPrintToChat(client, "%s%t", MESSAGE_COLOUR, "Commander Language", langName);  
 		}
 	}
 }

--- a/addons/sourcemod/scripting/ndpc/features/file_logging.sp
+++ b/addons/sourcemod/scripting/ndpc/features/file_logging.sp
@@ -27,7 +27,7 @@ void BuildLogFilePath() // Build Log File System Path
 
 void NoTranslationFound(int client, const char[] sArgs)
 {
-	PrintToChat(client, "%s%t %s%t.", TAG_COLOUR, "Translate Tag", MESSAGE_COLOUR, "No Translate Keyword");
+	CPrintToChat(client, "%s%t %s%t.", TAG_COLOUR, "Translate Tag", MESSAGE_COLOUR, "No Translate Keyword");
 	
 	char toLog[32];
 	Format(toLog, sizeof(toLog), "[Not a Keyword] %s", sArgs);

--- a/addons/sourcemod/scripting/ndpc/features/team_lang.sp
+++ b/addons/sourcemod/scripting/ndpc/features/team_lang.sp
@@ -71,7 +71,7 @@ void PrintTLangToTeam(int team, const char[] printOut)
 			char ToPrint[128];
 			Format(ToPrint, sizeof(ToPrint), "%T", "Team Languages", client, printOut);
 			
-			PrintToChat(client, "%s%s", MESSAGE_COLOUR, ToPrint);	
+			CPrintToChat(client, "%s%s", MESSAGE_COLOUR, ToPrint);	
 		}
 	}
 }

--- a/addons/sourcemod/scripting/ndpc/reg_functions.sp
+++ b/addons/sourcemod/scripting/ndpc/reg_functions.sp
@@ -14,5 +14,5 @@ int GetStringSpaceCount(const char[] sArgs)
 /* Wrapper for printing a translation to client chat */
 void NPDC_PrintToChat(int client, const char[] sArgs)
 {
-	PrintToChat(client, "%s%t %s%s", TAG_COLOUR, "Translate Tag", MESSAGE_COLOUR, sArgs);
+	CPrintToChat(client, "%s%t %s%s", TAG_COLOUR, "Translate Tag", MESSAGE_COLOUR, sArgs);
 }

--- a/addons/sourcemod/scripting/ndpc/reg_functions.sp
+++ b/addons/sourcemod/scripting/ndpc/reg_functions.sp
@@ -1,3 +1,4 @@
+
 int GetStringSpaceCount(const char[] sArgs)
 {
 	int spaceCount = 0;
@@ -12,7 +13,12 @@ int GetStringSpaceCount(const char[] sArgs)
 }
 
 /* Wrapper for printing a translation to client chat */
-void NPDC_PrintToChat(int client, const char[] sArgs)
+void NDPC_PrintToChat(int client, int team, const char[] sArgs)
 {
-	CPrintToChat(client, "%s%t %s%s", TAG_COLOUR, "Translate Tag", MESSAGE_COLOUR, sArgs);
+	char pName[64];
+	GetClientName(client, pName, sizeof(pName));
+	
+	CPrintToChat(client, "%s%t %s%s: %s%s", TAG_COLOUR, "Translate Tag", 
+						tColour[team - 2], pName,
+						MESSAGE_COLOUR, sArgs);
 }

--- a/addons/sourcemod/scripting/ndpc/requests/build_req.sp
+++ b/addons/sourcemod/scripting/ndpc/requests/build_req.sp
@@ -63,9 +63,6 @@ void PrintSimpleBuildingRequest(int client, const char[] bName)
 {
 	int team = GetClientTeam(client);
 		
-	char pName[64];
-	GetClientName(client, pName, sizeof(pName));
-	
 	for (int idx = 0; idx <= MaxClients; idx++)
 	{
 		if (IsOnTeam(idx, team))
@@ -74,9 +71,9 @@ void PrintSimpleBuildingRequest(int client, const char[] bName)
 			Format(building, sizeof(building), "%T", bName, idx);
 				
 			char ToPrint[128];
-			Format(ToPrint, sizeof(ToPrint), "%T", "Simple Building Request", idx, pName, building);
+			Format(ToPrint, sizeof(ToPrint), "%T", "Simple Building Request", idx, building);
 				
-			NPDC_PrintToChat(idx, ToPrint);
+			NDPC_PrintToChat(idx, team, ToPrint);
 		}
 	}	
 }
@@ -85,9 +82,6 @@ void PrintSpotBuildingRequest(int client, const char[] bName, const char[] lName
 {
 	int team = GetClientTeam(client);
 		
-	char pName[64];
-	GetClientName(client, pName, sizeof(pName));
-	
 	for (int idx = 0; idx <= MaxClients; idx++)
 	{
 		if (IsOnTeam(idx, team))
@@ -99,9 +93,9 @@ void PrintSpotBuildingRequest(int client, const char[] bName, const char[] lName
 			Format(location, sizeof(location), "%T", lName, idx);
 				
 			char ToPrint[128];
-			Format(ToPrint, sizeof(ToPrint), "%T", "Spot Building Request", idx, pName, building, location);
+			Format(ToPrint, sizeof(ToPrint), "%T", "Spot Building Request", idx, building, location);
 			
-			NPDC_PrintToChat(idx, ToPrint); 
+			NDPC_PrintToChat(idx, team, ToPrint); 
 		}
 	}	
 }
@@ -110,9 +104,6 @@ void PrintCompassBuildingRequest(int client, const char[] bName, const char[] cN
 {
 	int team = GetClientTeam(client);
 		
-	char pName[64];
-	GetClientName(client, pName, sizeof(pName));
-		
 	for (int idx = 0; idx <= MaxClients; idx++)
 	{
 		if (IsOnTeam(idx, team))
@@ -124,10 +115,9 @@ void PrintCompassBuildingRequest(int client, const char[] bName, const char[] cN
 			Format(compass, sizeof(compass), "%T", cName, idx);
 				
 			char ToPrint[128];
-			Format(ToPrint, sizeof(ToPrint), "%T", "Compass Building Request", 
-								idx, pName, building, compass);
+			Format(ToPrint, sizeof(ToPrint), "%T", "Compass Building Request", idx, building, compass);
 								       
-			NPDC_PrintToChat(idx, ToPrint);
+			NDPC_PrintToChat(idx, team, ToPrint);
 		}
 	}	
 }
@@ -136,9 +126,6 @@ void PrintComplexBuildingRequest(int client, const char[] bName, const char[] lN
 {
 	int team = GetClientTeam(client);
 		
-	char pName[64];
-	GetClientName(client, pName, sizeof(pName));
-	
 	for (int idx = 0; idx <= MaxClients; idx++)
 	{
 		if (IsOnTeam(idx, team))
@@ -153,10 +140,9 @@ void PrintComplexBuildingRequest(int client, const char[] bName, const char[] lN
 			Format(compass, sizeof(compass), "%T", cName, idx);
 				
 			char ToPrint[128];
-			Format(ToPrint, sizeof(ToPrint), "%T", "Complex Building Request", 
-								       idx, pName, building, location, compass);
+			Format(ToPrint, sizeof(ToPrint), "%T", "Complex Building Request", idx, building, location, compass);
 								       
-			NPDC_PrintToChat(idx, ToPrint);
+			NDPC_PrintToChat(idx, team, ToPrint);
 		}
 	}
 }

--- a/addons/sourcemod/scripting/ndpc/requests/capture_req.sp
+++ b/addons/sourcemod/scripting/ndpc/requests/capture_req.sp
@@ -38,9 +38,6 @@ void PrintSimpleCaptureRequest(int client, const char[] rName)
 {
 	int team = GetClientTeam(client);
 		
-	char cName[64];
-	GetClientName(client, cName, sizeof(cName));
-		
 	for (int idx = 0; idx <= MaxClients; idx++)
 	{
 		if (IsOnTeam(idx, team))
@@ -49,9 +46,9 @@ void PrintSimpleCaptureRequest(int client, const char[] rName)
 			Format(resource, sizeof(resource), "%T", rName, idx);
 			
 			char ToPrint[128];
-			Format(ToPrint, sizeof(ToPrint), "%T", "Simple Capture Request", idx, cName, resource);
+			Format(ToPrint, sizeof(ToPrint), "%T", "Simple Capture Request", idx, resource);
 				
-			NPDC_PrintToChat(idx, ToPrint);
+			NDPC_PrintToChat(idx, team, ToPrint);
 		}
 	}
 }
@@ -59,9 +56,6 @@ void PrintSimpleCaptureRequest(int client, const char[] rName)
 void PrintExtendedCaptureRequest(int client, const char[] rName, const char[] lName)
 {
 	int team = GetClientTeam(client);
-		
-	char cName[64];
-	GetClientName(client, cName, sizeof(cName));
 		
 	for (int idx = 0; idx <= MaxClients; idx++)
 	{
@@ -74,9 +68,9 @@ void PrintExtendedCaptureRequest(int client, const char[] rName, const char[] lN
 			Format(compass, sizeof(compass), "%T", lName, idx);
 				
 			char ToPrint[128];
-			Format(ToPrint, sizeof(ToPrint), "%T", "Extended Capture Request", idx, cName, compass, resource);
+			Format(ToPrint, sizeof(ToPrint), "%T", "Extended Capture Request", idx, compass, resource);
 				
-			NPDC_PrintToChat(idx, ToPrint);
+			NDPC_PrintToChat(idx, team, ToPrint);
 		}
 	}	
 }

--- a/addons/sourcemod/scripting/ndpc/requests/repair_req.sp
+++ b/addons/sourcemod/scripting/ndpc/requests/repair_req.sp
@@ -82,9 +82,6 @@ void PrintBuildingRepairRequest(int client, const char[] bName)
 {
 	int team = GetClientTeam(client);
 		
-	char pName[64];
-	GetClientName(client, pName, sizeof(pName));
-		
 	for (int idx = 0; idx <= MaxClients; idx++)
 	{
 		if (IsOnTeam(idx, team))
@@ -93,9 +90,9 @@ void PrintBuildingRepairRequest(int client, const char[] bName)
 			Format(building, sizeof(building), "%T", bName, idx);
 				
 			char ToPrint[128];
-			Format(ToPrint, sizeof(ToPrint), "%T", "Building Repair Request", idx, pName, building);
+			Format(ToPrint, sizeof(ToPrint), "%T", "Building Repair Request", idx, building);
 			
-			NPDC_PrintToChat(idx, ToPrint); 
+			NDPC_PrintToChat(idx, team, ToPrint); 
 		}
 	}
 }
@@ -104,9 +101,6 @@ void Print_CompassBuilding_RepairRequest(int client, const char[] bName, const c
 {
 	int team = GetClientTeam(client);
 	
-	char pName[64];
-	GetClientName(client, pName, sizeof(pName));
-		
 	for (int idx = 0; idx <= MaxClients; idx++)
 	{
 		if (IsOnTeam(idx, team))
@@ -118,9 +112,9 @@ void Print_CompassBuilding_RepairRequest(int client, const char[] bName, const c
 			Format(compass, sizeof(compass), "%T", cName, idx);
 				
 			char ToPrint[128];
-			Format(ToPrint, sizeof(ToPrint), "%T", "Build Comp Repair Request", idx, pName, compass, building);
+			Format(ToPrint, sizeof(ToPrint), "%T", "Build Comp Repair Request", idx, compass, building);
 			
-			NPDC_PrintToChat(idx, ToPrint); 
+			NPDC_PrintToChat(idx, team, ToPrint); 
 		}
 	}	
 }
@@ -129,9 +123,6 @@ void PrintCompassRepairRequest(int client, const char[] cName)
 {
 	int team = GetClientTeam(client);
 		
-	char pName[64];
-	GetClientName(client, pName, sizeof(pName));
-		
 	for (int idx = 0; idx <= MaxClients; idx++)
 	{
 		if (IsOnTeam(idx, team))
@@ -140,9 +131,9 @@ void PrintCompassRepairRequest(int client, const char[] cName)
 			Format(compass, sizeof(compass), "%T", cName, idx);
 				
 			char ToPrint[128];
-			Format(ToPrint, sizeof(ToPrint), "%T", "Compass Repair Request", idx, pName, compass);
+			Format(ToPrint, sizeof(ToPrint), "%T", "Compass Repair Request", idx, compass);
 				
-			NPDC_PrintToChat(idx, ToPrint); 
+			NPDC_PrintToChat(idx, team, ToPrint); 
 		}
 	}	
 }
@@ -150,9 +141,6 @@ void PrintCompassRepairRequest(int client, const char[] cName)
 void Print_CompassLocation_RepairRequest(int client, const char[] cName, const char[] lName)
 {
 	int team = GetClientTeam(client);
-		
-	char pName[64];
-	GetClientName(client, pName, sizeof(pName));
 		
 	for (int idx = 0; idx <= MaxClients; idx++)
 	{
@@ -165,9 +153,9 @@ void Print_CompassLocation_RepairRequest(int client, const char[] cName, const c
 			Format(location, sizeof(location), "%T", lName, idx);
 				
 			char ToPrint[128];
-			Format(ToPrint, sizeof(ToPrint), "%T", "Comp Loc Repair Request", idx, pName, compass, location);
+			Format(ToPrint, sizeof(ToPrint), "%T", "Comp Loc Repair Request", idx, compass, location);
 				
-			NPDC_PrintToChat(idx, ToPrint); 
+			NDPC_PrintToChat(idx, team, ToPrint); 
 		}
 	}
 }
@@ -175,9 +163,6 @@ void Print_CompassLocation_RepairRequest(int client, const char[] cName, const c
 void PrintLocationRepairRequest(int client, const char[] lName)
 {
 	int team = GetClientTeam(client);
-		
-	char pName[64];
-	GetClientName(client, pName, sizeof(pName));
 		
 	for (int idx = 0; idx <= MaxClients; idx++)
 	{
@@ -187,9 +172,9 @@ void PrintLocationRepairRequest(int client, const char[] lName)
 			Format(location, sizeof(location), "%T", lName, idx);
 			
 			char ToPrint[128];
-			Format(ToPrint, sizeof(ToPrint), "%T", "Location Repair Request", idx, pName, location);
+			Format(ToPrint, sizeof(ToPrint), "%T", "Location Repair Request", idx, location);
 				
-			NPDC_PrintToChat(idx, ToPrint); 
+			NDPC_PrintToChat(idx, team, ToPrint); 
 		}
 	}	
 }
@@ -197,9 +182,6 @@ void PrintLocationRepairRequest(int client, const char[] lName)
 void Print_LocationBuilding_RepairRequest(int client, const char[] bName, const char[] lName)
 {
 	int team = GetClientTeam(client);
-		
-	char pName[64];
-	GetClientName(client, pName, sizeof(pName));
 		
 	for (int idx = 0; idx <= MaxClients; idx++)
 	{
@@ -212,9 +194,9 @@ void Print_LocationBuilding_RepairRequest(int client, const char[] bName, const 
 			Format(location, sizeof(location), "%T", lName, idx);
 				
 			char ToPrint[128];
-			Format(ToPrint, sizeof(ToPrint), "%T", "Build Loc Repair Request", idx, pName, building, location);
+			Format(ToPrint, sizeof(ToPrint), "%T", "Build Loc Repair Request", idx, building, location);
 				
-			NPDC_PrintToChat(idx, ToPrint); 
+			NDPC_PrintToChat(idx, team, ToPrint); 
 		}
 	}	
 }
@@ -222,9 +204,6 @@ void Print_LocationBuilding_RepairRequest(int client, const char[] bName, const 
 void PrintExtendedRepairRequest(int client, const char[] bName, const char[] cName, const char[] lName)
 {
 	int team = GetClientTeam(client);
-		
-	char pName[64];
-	GetClientName(client, pName, sizeof(pName));
 		
 	for (int idx = 0; idx <= MaxClients; idx++)
 	{
@@ -240,9 +219,9 @@ void PrintExtendedRepairRequest(int client, const char[] bName, const char[] cNa
 			Format(location, sizeof(location), "%T", lName, idx);
 			
 			char ToPrint[128];
-			Format(ToPrint, sizeof(ToPrint), "%T", "Extended Repair Request", idx, pName, building, compass, location);
+			Format(ToPrint, sizeof(ToPrint), "%T", "Extended Repair Request", idx, building, compass, location);
 	
-			NPDC_PrintToChat(idx, ToPrint); 
+			NDPC_PrintToChat(idx, team, ToPrint); 
 		}
 	}	
 }

--- a/addons/sourcemod/scripting/ndpc/requests/repair_req.sp
+++ b/addons/sourcemod/scripting/ndpc/requests/repair_req.sp
@@ -114,7 +114,7 @@ void Print_CompassBuilding_RepairRequest(int client, const char[] bName, const c
 			char ToPrint[128];
 			Format(ToPrint, sizeof(ToPrint), "%T", "Build Comp Repair Request", idx, compass, building);
 			
-			NPDC_PrintToChat(idx, team, ToPrint); 
+			NDPC_PrintToChat(idx, team, ToPrint); 
 		}
 	}	
 }
@@ -133,7 +133,7 @@ void PrintCompassRepairRequest(int client, const char[] cName)
 			char ToPrint[128];
 			Format(ToPrint, sizeof(ToPrint), "%T", "Compass Repair Request", idx, compass);
 				
-			NPDC_PrintToChat(idx, team, ToPrint); 
+			NDPC_PrintToChat(idx, team, ToPrint); 
 		}
 	}	
 }

--- a/addons/sourcemod/scripting/ndpc/requests/research_req.sp
+++ b/addons/sourcemod/scripting/ndpc/requests/research_req.sp
@@ -34,9 +34,6 @@ void PrintSimpleResearchRequest(int client, const char[] rName)
 {
 	int team = GetClientTeam(client);
 		
-	char pName[64];
-	GetClientName(client, pName, sizeof(pName));
-		
 	for (int idx = 0; idx <= MaxClients; idx++)
 	{
 		if (IsOnTeam(idx, team))
@@ -45,9 +42,9 @@ void PrintSimpleResearchRequest(int client, const char[] rName)
 			Format(research, sizeof(research), "%T", rName, idx);
 				
 			char ToPrint[128];
-			Format(ToPrint, sizeof(ToPrint), "%T", "Simple Research Request", idx, pName, research);
+			Format(ToPrint, sizeof(ToPrint), "%T", "Simple Research Request", idx, research);
 				
-			NPDC_PrintToChat(idx, ToPrint); 
+			NDPC_PrintToChat(idx, team, ToPrint); 
 		}
 	}
 }

--- a/updater/nd_universal_translator/translations/es/nd_universal_translator.phrases.txt
+++ b/updater/nd_universal_translator/translations/es/nd_universal_translator.phrases.txt
@@ -7,7 +7,6 @@
 //
 "Phrases"
 {
-
 	"Team Languages"
 	{
 		"es"		"Idiomas de equipo: {1}"
@@ -102,5 +101,4 @@
 	{
 		"es"		"Izquierda"
 	}
-
 }

--- a/updater/nd_universal_translator/translations/es/nd_universal_translator.phrases.txt
+++ b/updater/nd_universal_translator/translations/es/nd_universal_translator.phrases.txt
@@ -18,36 +18,6 @@
 		"es"		"El idioma del cliente de juego del comandante es {1}."
 	}
 
-	"Simple Building Request"
-	{
-		"es"		" {1} está solicitando {2} "
-	}
-
-	"Compass Building Request"
-	{
-		"es"		"{1} está solicitando {2} en el lado {3}"
-	}
-
-	"Spot Building Request"
-	{
-		"es"		" {1} solicita {2} en {3} "
-	}
-
-	"Complex Building Request"
-	{
-		"es"		" {1} está solicitando {2} en el {4} {3} "
-	}
-
-	"Simple Capture Request"
-	{
-		"es"		" {1} dice: capturar {2} "
-	}
-	
-	"Extended Capture Request"
-	{
-		"es"		" {1} dice: capturar {2} {3} "
-	}
-
 	"Base Tert"
 	{
 		"es"		"Terciario de la base"

--- a/updater/nd_universal_translator/translations/nd_universal_translator.phrases.txt
+++ b/updater/nd_universal_translator/translations/nd_universal_translator.phrases.txt
@@ -17,153 +17,155 @@
 	/* Building request messages */
 	"Simple Building Request"
 	{
-		//{1} = Player's Name
-		//{2} = Building Name from structminigame.phrases
+		//{1} = Building Name from structminigame.phrases
 		//
-		//Example: Vertex is requesting a supply station.
-		"#format"	"{1:s},{2:s}"
-		"en"		"{1} is requesting {2}"
+		//Phrase Ex: Build a supply station.
+		//Final Ex: (Translator) Vertex: Build a supply station.
+		"#format"	"{2:s}"
+		"en"		"Build {1}"
 	}
 	
 	"Compass Building Request"
 	{
-		//{1} = Player's Name
-		//{2} = Building Name from structminigame.phrases
-		//{3} = Compass Name (see bellow)
+		//{1} = Building Name from structminigame.phrases
+		//{2} = Compass Name (see bellow)
 		//
-		//Example: Vertex is requesting a Supply Station on the west side.
-		"#format"	"{1:s},{2:s},{3:s}"
-		"en"		"{1} is requesting {2} on the {3} side"
+		//Phrase Ex: Build a Supply Station on the west side
+		//Final Ex: (Translator) Vertex: Build a Supply Station on the west side.
+		"#format"	"{1:s},{2:s}"
+		"en"		"Build {1} on the {2} side"
 	}
 	
 	"Spot Building Request"
 	{
-		//{1} = Player's Name
-		//{2} = Building Name from structminigame.phrases
-		//{3} = Location Name (see bellow)
+		//{1} = Building Name from structminigame.phrases
+		//{2} = Location Name (see bellow)
 		//
-		//Example: Vertex is requesting a Transport Gate at base.
+		//Phrase Ex: Build a Transport Gate at base.
+		//Final Ex: (Translator) Vertex: Build a Transport Gate at base.
 		"#format"	"{1:s},{2:s},{3:s}"
-		"en"		"{1} is requesting {2} at {3}"
+		"en"		"Build {2} at {3}"
 	}
 	
 	"Complex Building Request"
 	{
-		//{1} = Player's Name
-		//{2} = Building Name from structminigame.phrases
-		//{3} = Location Name (see bellow)
-		//{4} = Compass Name (see bellow)
+		//{1} = Building Name from structminigame.phrases
+		//{2} = Location Name (see bellow)
+		//{3} = Compass Name (see bellow)
 		//
-		//Example: Vertex is requesting a Relay Tower at the north secondary
-		"#format"	"{1:s},{2:s},{3:s},{4:s}"
-		"en" 		"{1} is requesting {2} at the {4} {3}"
+		//Phrase Ex: Build a Relay Tower at the north secondary
+		//Final Ex: (Translator) Vertex: Build a Relay Tower at the north secondary
+		"#format"	"{1:s},{2:s},{3:s}"
+		"en" 		"Build {1} at the {3} {2}"
 	}
 	
 	/* Research Messages */
 	"Simple Research Request"
 	{
-		//{1} = Player's Name
-		//{2} = Research Name
-		"#format"	"{1:s},{2:s}"
-		"en"		"{1} is requesting {2} research."
+		//{1} = Research Name
+		//
+		//Phrase Ex: Research Advanced Kits.
+		//Final Ex: (Translator) Vertex: Research Advanced Kits.
+		"#format"	"{1:s}"
+		"en"		"Research {1}"
 	}
 	
 	/* Repair Requests */	
 	"Building Repair Request"
 	{
-		//{1} = Player Name
-		//{2} = Building Name
+		//{1} = Building Name
 		//
-		//Example: Vertex says repair the transport gate.
+		//Phrase Ex: Repair the transport gate.
+		//Final Ex: (Translator) Vertex: Repair the transport gate.
 		"#format"	"{1:s},{2:s}"
-		"en"		"{1} says repair the {2}"
+		"en"		"Repair the {1}"
 	}
 	
 	"Build Comp Repair Request"
 	{
-		//{1} = Player Name
-		//{2} = Compass Position
-		//{3} = Building Name
+		//{1} = Compass Position
+		//{2} = Building Name
 		//
-		//Example: Vertex says repair the north supply station.
-		"#format"	"{1:s},{2:s},{3:s}"
-		"en"		"{1} says repair the {2} {3}"	
+		//Phrase Ex: Repair the north supply station.
+		//Final Ex: (Translator) Vertex: Repair the north supply station.
+		"#format"	"{1:s},{2:s}"
+		"en"		"Repair the {1} {2}"	
 	}
 	
 	"Compass Repair Request"
 	{
-		//{1} = Player Name
-		//{2} = Compass Position
+		//{1} = Compass Position
 		//
-		//Example: Vertex is requesting repairs on the south side of the map.
-		"#format"	"{1:s},{2:s}"
-		"en"		"{1} is requesting repairs on the {2} side of the map"		
+		//Phrase Ex: Repairs needed on the left side of the map
+		//Final Ex: (Translator) Vertex: Repairs are required on the left side of the map.
+		"#format"	"{1:s}"
+		"en"		"Repairs needed on the {1} side of the map"		
 	}
 	
 	"Comp Loc Repair Request"
 	{
-		//{1} = Player Name
-		//{2} = Compass Position
-		//{3} = Location Name
+		//{1} = Compass Position
+		//{2} = Location Name
 		//
-		//Example: Vertex is requesting repairs at the east secodnary.
-		"#format"	"{1:s},{2:s},{3:s}"
-		"en"		"{1} is requesting repairs at the {2} {3}"		
+		//Phrase Ex: Repairs needed at the east secodnary.
+		//Final Ex: (Translator) Vertex: Repairs needed at the east secondary
+		"#format"	"{1:s},{2:s}"
+		"en"		"Repairs needed at the {1} {2}"		
 	}
 	
 	"Location Repair Request"
 	{
-		//{1} = Player Name
-		//{2} = Location Name
+		//{1} = Location Name
 		//
-		//Example: Vertex is requesting repairs at the rooftop.
-		"#format"	"{1:s},{2:s}"
-		"en"		"{1} is requesting repairs at {2}"
+		//Phrase Ex: Repairs needed at secondary.
+		///Final Ex: (Translator) Vertex: Repairs needed at the rooftop.
+		"#format"	"{1:s}"
+		"en"		"Repairs needed at {1}"
 	}
 	
 	"Build Loc Repair Request"
 	{
-		//{1} = Player Name
-		//{2} = Building Name
-		//{3} = Location Name		
+		//{1} = Building Name
+		//{2} = Location Name		
 		//
-		//Example: Vertex says repair the rocket turret at prime.
-		"#format"	"{1:s},{2:s},{3:s}"
-		"en"		"{1} says repair the {2} at {3}"	
+		//Phrase Ex: Repair the rocket turret at prime 		
+		///Final Ex: (Translator) Vertex: Repair the rocket turret at prime.
+		"#format"	"{1:s},{2:s}"
+		"en"		"Repair the {1} at {2}"	
 	}
 	
 	"Extended Repair Request"
 	{
-		//{1} = Player Name
-		//{2} = Building Name
-		//{3} = Compass Position
-		//{4} = Location Name
+		//{1} = Building Name
+		//{2} = Compass Position
+		//{3} = Location Name
 		//
-		//Example: Vertex says repair the transport gate at west secondary.
-		"#format"	"{1:s},{2:s},{3:s},{4:s}"
-		"en"		"{1} says repair the {2} at {3} {4}"	
+		//Phrase Ex: Repair the transport gate at west secondary		
+		///Final Ex: (Translator) Vertex: Repair the transport gate at west secondary.
+		"#format"	"{1:s},{2:s},{3:s}"
+		"en"		"Repair the {1} at {2} {3}"
 	}
 	
 	/* Capture Messages */
 	"Simple Capture Request"
 	{
-		//{1} = Player's name
-		//{2} = Resource Name (see bellow)
+		//{1} = Resource Name (see bellow)
 		//
-		//Example: Vertex says capture secondary
-		"#format"	"{1:s},{2:s}"
-		"en"		"{1} says capture {2}"
+		//Phrase Ex: Capture secondary
+		//Final Ex: (Translator) Vertex: Capture Secondary.
+		"#format"	"{1:s}"
+		"en"		"Capture {1}"
 	}
 	
 	"Extended Capture Request"
 	{
-		//{1} = Player's name
-		//{2} = Compass Position (see bellow)
-		//{3} = Resource Name (see bellow)
+		//{1} = Compass Position (see bellow)
+		//{2} = Resource Name (see bellow)
 		//
-		//Example: Vertex says capture secondary
-		"#format"	"{1:s},{2:s},{3:s}"
-		"en"		"{1} says capture {2} {3}"
+		//Phrase Ex: Capture East Secondary
+		//Final Ex: (Translator) Vertex: Capture East Secondary.
+		"#format"	"{1:s},{2:s}"
+		"en"		"Capture {1} {2}"
 	}
 	
 	"Base Tert"

--- a/updater/nd_universal_translator/translations/ru/nd_universal_translator.phrases.txt
+++ b/updater/nd_universal_translator/translations/ru/nd_universal_translator.phrases.txt
@@ -18,31 +18,6 @@
 		"ru"		"Язык игры командира {1}"
 	}
 
-	"Simple Building Request"
-	{
-		"ru"		"{1} просит {2}"
-	}
-
-	"Spot Building Request"
-	{
-		"ru"		"{1} просит {2} на {3}"
-	}
-
-	"Complex Building Request"
-	{
-		"ru"		"{1} просит {2} у {4} {3}"
-	}
-
-	"Simple Capture Request"
-	{
-		"ru"		"{1} приказ захватиь {2}"
-	}
-	
-	"Extended Capture Request"
-	{
-		"ru"		"{1} приказ захватиь {2} {3}"
-	}
-
 	"Base Tert"
 	{
 		"ru"		"Маленький ресурс на базе"
@@ -127,5 +102,4 @@
 	{
 		"ru"		"Слева"
 	}
-
 }

--- a/updater/nd_universal_translator/translations/ru/nd_universal_translator.phrases.txt
+++ b/updater/nd_universal_translator/translations/ru/nd_universal_translator.phrases.txt
@@ -7,7 +7,6 @@
 //
 "Phrases"
 {
-
 	"Team Languages"
 	{
 		"ru"		"Язык игры команды"


### PR DESCRIPTION
- Use colors.inc for chat colours.

- Move player name outside of phrases and to start of translation message.

- Light the player name up blue or red depending on the team