### PR TITLE
Majorly Cleanup UT Code

### DIFF
--- a/addons/sourcemod/scripting/ndpc/reg_functions.sp
+++ b/addons/sourcemod/scripting/ndpc/reg_functions.sp
@@ -19,6 +19,9 @@ int Client_GetNext(int team, int index = 1)
 	return -1;
 }
 
+#define PRINT_SIZE 128
+#define PHRASE_SIZE 64
+
 /* Get the space count in a given chat message (or string) */
 int GetStringSpaceCount(const char[] sArgs)
 {
@@ -47,8 +50,8 @@ void NDPC_PrintRequestEx(int team, const char[] request, const char[] pName, con
 {
 	int size = sizeof(args[]);	
 
-	char transString[size][64];
-	char ToPrint[128];	
+	char transString[size][PHRASE_SIZE];
+	char ToPrint[PRINT_SIZE];	
 	
 	LOOP_TEAM(idx, team) 
 	{
@@ -57,9 +60,9 @@ void NDPC_PrintRequestEx(int team, const char[] request, const char[] pName, con
 		// Reswitching for each client is bad, but it saves ALOT of duplication
 		switch (size)
 		{
-			case 1:	Format(ToPrint, sizeof(ToPrint), "%T", request, idx, transString[0]);						
-			case 2:	Format(ToPrint, sizeof(ToPrint), "%T", request, idx, transString[0], transString[1]);
-			case 3:	Format(ToPrint, sizeof(ToPrint), "%T", request, idx, transString[0], transString[1] ,transString[2]);
+			case 1:	Format(ToPrint, PRINT_SIZE, "%T", request, idx, transString[0]);						
+			case 2:	Format(ToPrint, PRINT_SIZE, "%T", request, idx, transString[0], transString[1]);
+			case 3:	Format(ToPrint, PRINT_SIZE, "%T", request, idx, transString[0], transString[1] ,transString[2]);
 		}
 				
 		NDPC_PrintToChat(idx, pName, ToPrint);		
@@ -86,9 +89,9 @@ char GetTransString(int client, const char[][] args)
 {
 	int size = sizeof(args[]);	
 	
-	char trans = new char[size][64];	
+	char trans = new char[size][PHRASE_SIZE];	
 	for (int idx = 0; idx < size; idx++) {
-		Format(trans[idx], 64, "%T", args[idx], client);	
+		Format(trans[idx], PHRASE_SIZE, "%T", args[idx], client);	
 	}	
 
 	return trans;

--- a/addons/sourcemod/scripting/ndpc/reg_functions.sp
+++ b/addons/sourcemod/scripting/ndpc/reg_functions.sp
@@ -86,7 +86,7 @@ char GetTransString(int client, const char[][] args)
 {
 	int size = sizeof(args[]);	
 	
-	char trans[size][64];	
+	char trans = new char[size][64];	
 	for (int idx = 0; idx < size; idx++) {
 		Format(trans[idx], 64, "%T", args[idx], client);	
 	}	

--- a/addons/sourcemod/scripting/ndpc/reg_functions.sp
+++ b/addons/sourcemod/scripting/ndpc/reg_functions.sp
@@ -36,7 +36,7 @@ int GetStringSpaceCount(const char[] sArgs)
 	return spaceCount;
 }
 
-void NDPC_PrintRequest(int team, const char[] request, const char[] pName)
+stock void NDPC_PrintSimpleRequest(int team, const char[] request, const char[] pName)
 {
 	LOOP_TEAM(idx, team) 
 	{
@@ -46,27 +46,41 @@ void NDPC_PrintRequest(int team, const char[] request, const char[] pName)
 	}	
 }
 
-void NDPC_PrintRequestEx(int team, const char[] request, const char[] pName, char[][] args)
+stock void NDPC_PrintRequestS1(int team, const char[] request, const char[] pName, const char[] phrase)
 {
-	int size = sizeof(args[]);	
-
-	char transString[size][PHRASE_SIZE];
-	char ToPrint[PRINT_SIZE];	
-	
 	LOOP_TEAM(idx, team) 
 	{
-		Format(transString, sizeof(transSize), GetTransString(client, args));
+		char ToPrint[128];
+		Format(ToPrint, sizeof(ToPrint), "%T", request, idx, GetTransString(idx, phrase));
+		NDPC_PrintToChat(idx, pName, ToPrint);	
+	}
+}
+
+stock void NDPC_PrintRequestS2(int team, const char[] request, const char[] pName, const char[2][] phrase)
+{
+	LOOP_TEAM(idx, team) 
+	{
+		char ToPrint[128];
+		Format(ToPrint, sizeof(ToPrint), "%T", request, idx, 		
+				GetTransString(idx, phrase[0]),
+				GetTransString(idx, phrase[1]));
 		
-		// Reswitching for each client is bad, but it saves ALOT of duplication
-		switch (size)
-		{
-			case 1:	Format(ToPrint, PRINT_SIZE, "%T", request, idx, transString[0]);						
-			case 2:	Format(ToPrint, PRINT_SIZE, "%T", request, idx, transString[0], transString[1]);
-			case 3:	Format(ToPrint, PRINT_SIZE, "%T", request, idx, transString[0], transString[1] ,transString[2]);
-		}
+		NDPC_PrintToChat(idx, pName, ToPrint);	
+	}
+}
+
+stock void NDPC_PrintRequestS3(int team, const char[] request, const char[] pName, const char[3][] phrase)
+{
+	LOOP_TEAM(idx, team) 
+	{
+		char ToPrint[128];
+				Format(ToPrint, sizeof(ToPrint), "%T", request, idx, 		
+				GetTransString(idx, phrase[0]),
+				GetTransString(idx, phrase[1]),
+				GetTransString(idx, phrase[2]));
 				
-		NDPC_PrintToChat(idx, pName, ToPrint);		
-	}	
+		NDPC_PrintToChat(idx, pName, ToPrint);	
+	}
 }
 
 /* Wrapper for printing a translation to client chat */
@@ -85,14 +99,9 @@ void NDPC_PrintNoTransFound(int client)
 }
 
 /* Translation Strings */
-char GetTransString(int client, char[][] args)
+char GetTransString(int client, const char[] tName)
 {
-	int size = sizeof(args[]);	
-	
-	char trans = new char[size][PHRASE_SIZE];	
-	for (int idx = 0; idx < size; idx++) {
-		Format(trans[idx], PHRASE_SIZE, "%T", args[idx], client);	
-	}	
-
+	char trans[PHRASE_SIZE];
+	Format(trans, PHRASE_SIZE, "%T", tName, client);
 	return trans;
 }

--- a/addons/sourcemod/scripting/ndpc/reg_functions.sp
+++ b/addons/sourcemod/scripting/ndpc/reg_functions.sp
@@ -49,23 +49,9 @@ void NDPC_PrintNoTransFound(int client)
 }
 
 /* Translation Strings */
-char GetBuildingTrans(int client, const char[] bName)
+char GetTransString(int client, const char[] tName)
 {
-	char building[64];
-	Format(building, sizeof(building), "%T", bName, client);
-	return building;
-}
-
-char GetLocationTrans(int client, const char[] lName)
-{
-	char location[32];
-	Format(location, sizeof(location), "%T", lName, client);
-	return location;
-}
-
-char GetCompassTrans(int client, const char[] cName)
-{
-	char compass[32];
-	Format(compass, sizeof(compass), "%T", cName, client);
-	return compass;
+	char trans[64];
+	Format(trans, sizeof(trans), "%T", tName, client);
+	return trans;
 }

--- a/addons/sourcemod/scripting/ndpc/reg_functions.sp
+++ b/addons/sourcemod/scripting/ndpc/reg_functions.sp
@@ -46,38 +46,38 @@ stock void NDPC_PrintRequestS0(int team, const char[] request, const char[] pNam
 	}	
 }
 
-stock void NDPC_PrintRequestS1(int team, const char[] request, const char[] pName, const char[] phrase)
+stock void NDPC_PrintRequestS1(int team, const char[] request, const char[] pName, const char[] p1)
 {
 	LOOP_TEAM(idx, team) 
 	{
 		char ToPrint[128];
-		Format(ToPrint, sizeof(ToPrint), "%T", request, idx, GetTransString(idx, phrase));
+		Format(ToPrint, sizeof(ToPrint), "%T", request, idx, GetTransString(idx, p1));
 		NDPC_PrintToChat(idx, pName, ToPrint);	
 	}
 }
 
-stock void NDPC_PrintRequestS2(int team, const char[] request, const char[] pName, const char[2][] phrase)
+stock void NDPC_PrintRequestS2(int team, const char[] request, const char[] pName, const char[] p1, const char[] p2)
 {
 	LOOP_TEAM(idx, team) 
 	{
 		char ToPrint[128];
 		Format(ToPrint, sizeof(ToPrint), "%T", request, idx, 		
-				GetTransString(idx, phrase[0]),
-				GetTransString(idx, phrase[1]));
+				GetTransString(idx, p1),
+				GetTransString(idx, p2));
 		
 		NDPC_PrintToChat(idx, pName, ToPrint);	
 	}
 }
 
-stock void NDPC_PrintRequestS3(int team, const char[] request, const char[] pName, const char[3][] phrase)
+stock void NDPC_PrintRequestS3(int team, const char[] request, const char[] pName, const char[] p1, const char[] p2, const char[] p3)
 {
 	LOOP_TEAM(idx, team) 
 	{
 		char ToPrint[128];
 				Format(ToPrint, sizeof(ToPrint), "%T", request, idx, 		
-				GetTransString(idx, phrase[0]),
-				GetTransString(idx, phrase[1]),
-				GetTransString(idx, phrase[2]));
+				GetTransString(idx, p1),
+				GetTransString(idx, p2),
+				GetTransString(idx, p2));
 				
 		NDPC_PrintToChat(idx, pName, ToPrint);	
 	}

--- a/addons/sourcemod/scripting/ndpc/reg_functions.sp
+++ b/addons/sourcemod/scripting/ndpc/reg_functions.sp
@@ -46,7 +46,7 @@ void NDPC_PrintRequest(int team, const char[] request, const char[] pName)
 	}	
 }
 
-void NDPC_PrintRequestEx(int team, const char[] request, const char[] pName, const char[][] args)
+void NDPC_PrintRequestEx(int team, const char[] request, const char[] pName, char[][] args)
 {
 	int size = sizeof(args[]);	
 
@@ -85,7 +85,7 @@ void NDPC_PrintNoTransFound(int client)
 }
 
 /* Translation Strings */
-char GetTransString(int client, const char[][] args)
+char GetTransString(int client, char[][] args)
 {
 	int size = sizeof(args[]);	
 	

--- a/addons/sourcemod/scripting/ndpc/reg_functions.sp
+++ b/addons/sourcemod/scripting/ndpc/reg_functions.sp
@@ -74,7 +74,7 @@ stock void NDPC_PrintRequestS3(int team, const char[] request, const char[] pNam
 	LOOP_TEAM(idx, team) 
 	{
 		char ToPrint[128];
-				Format(ToPrint, sizeof(ToPrint), "%T", request, idx, 		
+		Format(ToPrint, sizeof(ToPrint), "%T", request, idx, 		
 				GetTransString(idx, p1),
 				GetTransString(idx, p2),
 				GetTransString(idx, p2));

--- a/addons/sourcemod/scripting/ndpc/reg_functions.sp
+++ b/addons/sourcemod/scripting/ndpc/reg_functions.sp
@@ -33,6 +33,39 @@ int GetStringSpaceCount(const char[] sArgs)
 	return spaceCount;
 }
 
+void NDPC_PrintRequest(int team, const char[] request, const char[] pName)
+{
+	LOOP_TEAM(idx, team) 
+	{
+		char ToPrint[128];
+		Format(ToPrint, sizeof(ToPrint), "%T", request, idx);
+		NDPC_PrintToChat(idx, pName, ToPrint);	
+	}	
+}
+
+void NDPC_PrintRequestEx(int team, const char[] request, const char[] pName, const char[][] args)
+{
+	int size = sizeof(args[]);	
+
+	char transString[size][64];
+	char ToPrint[128];	
+	
+	LOOP_TEAM(idx, team) 
+	{
+		Format(transString, sizeof(transSize), GetTransString(client, args));
+		
+		// Reswitching for each client is bad, but it saves ALOT of duplication
+		switch (size)
+		{
+			case 1:	Format(ToPrint, sizeof(ToPrint), "%T", request, idx, transString[0]);						
+			case 2:	Format(ToPrint, sizeof(ToPrint), "%T", request, idx, transString[0], transString[1]);
+			case 3:	Format(ToPrint, sizeof(ToPrint), "%T", request, idx, transString[0], transString[1] ,transString[2]);
+		}
+				
+		NDPC_PrintToChat(idx, pName, ToPrint);		
+	}	
+}
+
 /* Wrapper for printing a translation to client chat */
 void NDPC_PrintToChat(int client, const char[] pName, const char[] sArgs)
 {
@@ -49,9 +82,14 @@ void NDPC_PrintNoTransFound(int client)
 }
 
 /* Translation Strings */
-char GetTransString(int client, const char[] tName)
+char GetTransString(int client, const char[][] args)
 {
-	char trans[64];
-	Format(trans, sizeof(trans), "%T", tName, client);
+	int size = sizeof(args[]);	
+	
+	char trans[size][64];	
+	for (int idx = 0; idx < size; idx++) {
+		Format(trans[idx], 64, "%T", args[idx], client);	
+	}	
+
 	return trans;
 }

--- a/addons/sourcemod/scripting/ndpc/reg_functions.sp
+++ b/addons/sourcemod/scripting/ndpc/reg_functions.sp
@@ -47,3 +47,25 @@ void NDPC_PrintNoTransFound(int client)
 	//First segment is (Translator) in green. Second is "No keyword found" in olive
 	PrintToChat(client, "%s%t %s%t.", TAG_COLOUR, "Translate Tag", MESSAGE_COLOUR, "No Translate Keyword");
 }
+
+/* Translation Strings */
+char GetBuildingTrans(int client, const char[] bName)
+{
+	char building[64];
+	Format(building, sizeof(building), "%T", bName, client);
+	return building;
+}
+
+char GetLocationTrans(int client, const char[] lName)
+{
+	char location[32];
+	Format(location, sizeof(location), "%T", lName, client);
+	return location;
+}
+
+char GetCompassTrans(int client, const char[] cName)
+{
+	char compass[32];
+	Format(compass, sizeof(compass), "%T", cName, client);
+	return compass;
+}

--- a/addons/sourcemod/scripting/ndpc/reg_functions.sp
+++ b/addons/sourcemod/scripting/ndpc/reg_functions.sp
@@ -36,7 +36,7 @@ int GetStringSpaceCount(const char[] sArgs)
 	return spaceCount;
 }
 
-stock void NDPC_PrintSimpleRequest(int team, const char[] request, const char[] pName)
+stock void NDPC_PrintRequestS0(int team, const char[] request, const char[] pName)
 {
 	LOOP_TEAM(idx, team) 
 	{

--- a/addons/sourcemod/scripting/ndpc/requests/build_req.sp
+++ b/addons/sourcemod/scripting/ndpc/requests/build_req.sp
@@ -70,7 +70,7 @@ void PrintSimpleBuildingRequest(int team, const char[] pName, const char[] bName
 	{
 		char ToPrint[128];
 		Format(ToPrint, sizeof(ToPrint), "%T", "Simple Building Request", idx, 
-							GetBuildingTrans(idx, bName));
+							GetTransString(idx, bName));
 				
 		NDPC_PrintToChat(idx, pName, ToPrint);		
 	}	
@@ -82,8 +82,8 @@ void PrintSpotBuildingRequest(int team, const char[] pName, const char[] bName, 
 	{			
 		char ToPrint[128];
 		Format(ToPrint, sizeof(ToPrint), "%T", "Spot Building Request", idx,
-							GetBuildingTrans(idx, bName), 
-							GetLocationTrans(idx, lName));
+							GetTransString(idx, bName), 
+							GetTransString(idx, lName));
 			
 		NDPC_PrintToChat(idx, pName, ToPrint);		
 	}	
@@ -95,8 +95,8 @@ void PrintCompassBuildingRequest(int team, const char[] pName, const char[] bNam
 	{
 		char ToPrint[128];
 		Format(ToPrint, sizeof(ToPrint), "%T", "Compass Building Request", idx, 
-							GetBuildingTrans(idx, bName), 
-							GetCompassTrans(idx, cName));
+							GetTransString(idx, bName), 
+							GetTransString(idx, cName));
 							
 		NDPC_PrintToChat(idx, pName, ToPrint);		
 	}	
@@ -108,9 +108,9 @@ void PrintComplexBuildingRequest(int team, const char[] pName, const char[] bNam
 	{				
 		char ToPrint[128];
 		Format(ToPrint, sizeof(ToPrint), "%T", "Complex Building Request", idx, 
-							GetBuildingTrans(idx, bName),
-							GetLocationTrans(idx, lName),
-							GetCompassTrans(idx, cName));
+							GetTransString(idx, bName),
+							GetTransString(idx, lName),
+							GetTransString(idx, cName));
 							
 		NDPC_PrintToChat(idx, pName, ToPrint);		
 	}

--- a/addons/sourcemod/scripting/ndpc/requests/build_req.sp
+++ b/addons/sourcemod/scripting/ndpc/requests/build_req.sp
@@ -52,7 +52,7 @@ void bPrintMessage(int client, int team, const char[] pName, const char[] sArgs)
 		}
 		//if a valid compass position is found
 		else if (foundCompassName)
-			NDPC_PrintRequestS2(team, pName, "Compass Building Request"
+			NDPC_PrintRequestS2(team, pName, "Compass Building Request",
 							nd_request_building[building], 
 							nd_request_compass[compass]);
 		else 				

--- a/addons/sourcemod/scripting/ndpc/requests/build_req.sp
+++ b/addons/sourcemod/scripting/ndpc/requests/build_req.sp
@@ -68,11 +68,9 @@ void PrintSimpleBuildingRequest(int team, const char[] pName, const char[] bName
 {
 	LOOP_TEAM(idx, team) 
 	{
-		char building[64];
-		Format(building, sizeof(building), "%T", bName, idx);
-				
 		char ToPrint[128];
-		Format(ToPrint, sizeof(ToPrint), "%T", "Simple Building Request", idx, building);
+		Format(ToPrint, sizeof(ToPrint), "%T", "Simple Building Request", idx, 
+							GetBuildingTrans(idx, bName));
 				
 		NDPC_PrintToChat(idx, pName, ToPrint);		
 	}	
@@ -81,15 +79,11 @@ void PrintSimpleBuildingRequest(int team, const char[] pName, const char[] bName
 void PrintSpotBuildingRequest(int team, const char[] pName, const char[] bName, const char[] lName)
 {
 	LOOP_TEAM(idx, team) 
-	{
-		char building[64];
-		Format(building, sizeof(building), "%T", bName, idx);
-				
-		char location[32];
-		Format(location, sizeof(location), "%T", lName, idx);
-				
+	{			
 		char ToPrint[128];
-		Format(ToPrint, sizeof(ToPrint), "%T", "Spot Building Request", idx, building, location);
+		Format(ToPrint, sizeof(ToPrint), "%T", "Spot Building Request", idx,
+							GetBuildingTrans(idx, bName), 
+							GetLocationTrans(idx, lName));
 			
 		NDPC_PrintToChat(idx, pName, ToPrint);		
 	}	
@@ -99,15 +93,11 @@ void PrintCompassBuildingRequest(int team, const char[] pName, const char[] bNam
 {
 	LOOP_TEAM(idx, team) 
 	{
-		char building[64];
-		Format(building, sizeof(building), "%T", bName, idx);
-				
-		char compass[32];
-		Format(compass, sizeof(compass), "%T", cName, idx);
-				
 		char ToPrint[128];
-		Format(ToPrint, sizeof(ToPrint), "%T", "Compass Building Request", idx, building, compass);
-								       
+		Format(ToPrint, sizeof(ToPrint), "%T", "Compass Building Request", idx, 
+							GetBuildingTrans(idx, bName), 
+							GetCompassTrans(idx, cName));
+							
 		NDPC_PrintToChat(idx, pName, ToPrint);		
 	}	
 }
@@ -115,19 +105,13 @@ void PrintCompassBuildingRequest(int team, const char[] pName, const char[] bNam
 void PrintComplexBuildingRequest(int team, const char[] pName, const char[] bName, const char[] lName, const char[] cName)
 {
 	LOOP_TEAM(idx, team) 
-	{
-		char building[64];
-		Format(building, sizeof(building), "%T", bName, idx);
-				
-		char location[32];
-		Format(location, sizeof(location), "%T", lName, idx);
-				
-		char compass[32];
-		Format(compass, sizeof(compass), "%T", cName, idx);
-				
+	{				
 		char ToPrint[128];
-		Format(ToPrint, sizeof(ToPrint), "%T", "Complex Building Request", idx, building, location, compass);
-								       
+		Format(ToPrint, sizeof(ToPrint), "%T", "Complex Building Request", idx, 
+							GetBuildingTrans(idx, bName),
+							GetLocationTrans(idx, lName),
+							GetCompassTrans(idx, cName));
+							
 		NDPC_PrintToChat(idx, pName, ToPrint);		
 	}
 }

--- a/addons/sourcemod/scripting/ndpc/requests/build_req.sp
+++ b/addons/sourcemod/scripting/ndpc/requests/build_req.sp
@@ -14,104 +14,52 @@ bool CheckBuildingRequest(int client, int team, int spacesCount, const char[] pN
 	//If the chat messages starts with the word "build"
 	if (StrStartsWith(sArgs, "build"))
 	{
-		//Get the building the user is asking for
-		int building = GetBuildingByIndexEx(sArgs);
-		
-		//If a valid building name or alasis is found
-		if (foundInChatMessage(building))
-		{
-			//optionally, check if the user is asking for a location or compass
-			int location = GetSpotByIndex(sArgs);
-			int compass = GetCompassByIndex(sArgs);
-			
-			bool foundCompassName = foundInChatMessage(compass);
-			
-			//If a valid location is found
-			if (foundInChatMessage(location))
-			{
-				//if a valid compass position is found
-				if (foundCompassName)
-				{
-					PrintComplexBuildingRequest(	team, pName,
-									nd_request_building[building], 
-									nd_request_location[location],
-									nd_request_compass[compass]);
-					return true;
-				}
-				
-				PrintSpotBuildingRequest(	team, pName,
-								nd_request_building[building], 
-								nd_request_location[location]);
-				return true;
-			}
-			//if a valid compass position is found
-			else if (foundCompassName)
-			{
-				PrintCompassBuildingRequest(	team, pName, 
-								nd_request_building[building], 
-								nd_request_compass[compass]);
-				return true;
-			}
-					
-			PrintSimpleBuildingRequest(team, pName,	nd_request_building[building]);
-			return true;
-		}			
-			
-		NoTranslationFound(client, sArgs);
+		//print a translated building request
+		bPrintMessage(client, team, pName, sArgs);
 		return true;
 	}
 	
 	return false;
 }
 
-void PrintSimpleBuildingRequest(int team, const char[] pName, const char[] bName)
+void bPrintMessage(int client, int team, const char[] pName, const char[] sArgs)
 {
-	LOOP_TEAM(idx, team) 
+	//Get the building the user is asking for
+	int building = GetBuildingByIndexEx(sArgs);
+		
+	//If a valid building name or alasis is found
+	if (foundInChatMessage(building))
 	{
-		char ToPrint[128];
-		Format(ToPrint, sizeof(ToPrint), "%T", "Simple Building Request", idx, 
-							GetTransString(idx, bName));
-				
-		NDPC_PrintToChat(idx, pName, ToPrint);		
-	}	
-}
-
-void PrintSpotBuildingRequest(int team, const char[] pName, const char[] bName, const char[] lName)
-{
-	LOOP_TEAM(idx, team) 
-	{			
-		char ToPrint[128];
-		Format(ToPrint, sizeof(ToPrint), "%T", "Spot Building Request", idx,
-							GetTransString(idx, bName), 
-							GetTransString(idx, lName));
+		//optionally, check if the user is asking for a location or compass
+		int location = GetSpotByIndex(sArgs);
+		int compass = GetCompassByIndex(sArgs);
 			
-		NDPC_PrintToChat(idx, pName, ToPrint);		
-	}	
-}
-
-void PrintCompassBuildingRequest(int team, const char[] pName, const char[] bName, const char[] cName)
-{
-	LOOP_TEAM(idx, team) 
-	{
-		char ToPrint[128];
-		Format(ToPrint, sizeof(ToPrint), "%T", "Compass Building Request", idx, 
-							GetTransString(idx, bName), 
-							GetTransString(idx, cName));
-							
-		NDPC_PrintToChat(idx, pName, ToPrint);		
-	}	
-}
-
-void PrintComplexBuildingRequest(int team, const char[] pName, const char[] bName, const char[] lName, const char[] cName)
-{
-	LOOP_TEAM(idx, team) 
-	{				
-		char ToPrint[128];
-		Format(ToPrint, sizeof(ToPrint), "%T", "Complex Building Request", idx, 
-							GetTransString(idx, bName),
-							GetTransString(idx, lName),
-							GetTransString(idx, cName));
-							
-		NDPC_PrintToChat(idx, pName, ToPrint);		
-	}
+		bool foundCompassName = foundInChatMessage(compass);
+			
+		//If a valid location is found
+		if (foundInChatMessage(location))
+		{
+			//if a valid compass position is found
+			if (foundCompassName)
+				NDPC_PrintRequestS3(team, pName, "Complex Building Request",
+								nd_request_building[building], 
+								nd_request_location[location],
+								nd_request_compass[compass]);		
+			else 			
+				NDPC_PrintRequestS2(team, pName, "Spot Building Request",
+								nd_request_building[building], 
+								nd_request_location[location]);			
+		}
+		//if a valid compass position is found
+		else if (foundCompassName)
+			NDPC_PrintRequestS2(team, pName, "Compass Building Request"
+							nd_request_building[building], 
+							nd_request_compass[compass]);
+		else 				
+			NDPC_PrintRequestS1(team, pName, "Simple Building Request", 
+							nd_request_building[building]);		
+	} 
+	
+	else 			
+		NoTranslationFound(client, sArgs);		
 }

--- a/addons/sourcemod/scripting/ndpc/requests/capture_req.sp
+++ b/addons/sourcemod/scripting/ndpc/requests/capture_req.sp
@@ -11,58 +11,28 @@ bool CheckCaptureRequest(int client, int team, int spacesCount, const char[] pNa
 	
 	if (StrStartsWith(sArgs, "capture")) //if the string starts with capture
 	{
-		int resource = GetCaptureByIndex(sArgs);
-		
-		if (foundInChatMessage(resource))
-		{
-			int compass = GetCompassByIndex(sArgs);
-			
-			if (foundInChatMessage(compass))
-			{
-				PrintExtendedCaptureRequest(	team, pName,
-								nd_request_capture[resource], 
-								nd_request_compass[compass]);
-				return true;
-			}
-		
-			PrintSimpleCaptureRequest(team, pName, nd_request_capture[resource]);
-			return true;
-		}
-
-		NoTranslationFound(client, sArgs);
+		cPrintChatMessage(client, team, pName, sArgs);
 		return true;
 	}
 	
 	return false;
 }
 
-void PrintSimpleCaptureRequest(int team, const char[] pName, const char[] rName)
+void cPrintChatMessage(int client, int team, const char[] pName, const char[] sArgs)
 {
-	LOOP_TEAM(idx, team) 
+	int resource = GetCaptureByIndex(sArgs);
+		
+	if (foundInChatMessage(resource))
 	{
-		char resource[64];
-		Format(resource, sizeof(resource), "%T", rName, idx);
-			
-		char ToPrint[128];
-		Format(ToPrint, sizeof(ToPrint), "%T", "Simple Capture Request", idx, resource);
-				
-		NDPC_PrintToChat(idx, pName, ToPrint);		
+		int compass = GetCompassByIndex(sArgs);		
+		if (foundInChatMessage(compass))
+			NDPC_PrintRequestS2(team, pName, "Extended Capture Request",
+							nd_request_capture[resource], 
+							nd_request_compass[compass]);
+		else		
+			NDPC_PrintRequestS1(team, pName, "Simple Capture Request",
+							nd_request_capture[resource]);	
 	}
-}
-
-void PrintExtendedCaptureRequest(int team, const char[] pName, const char[] rName, const char[] lName)
-{		
-	LOOP_TEAM(idx, team) 
-	{
-		char resource[64];
-		Format(resource, sizeof(resource), "%T", rName, idx);
-				
-		char compass[32];
-		Format(compass, sizeof(compass), "%T", lName, idx);
-				
-		char ToPrint[128];
-		Format(ToPrint, sizeof(ToPrint), "%T", "Extended Capture Request", idx, compass, resource);
-				
-		NDPC_PrintToChat(idx, pName, ToPrint);		
-	}	
+	else
+		NoTranslationFound(client, sArgs);
 }

--- a/addons/sourcemod/scripting/ndpc/requests/repair_req.sp
+++ b/addons/sourcemod/scripting/ndpc/requests/repair_req.sp
@@ -13,189 +13,71 @@ bool CheckRepairRequest(int client, int team, int spacesCount, const char[] pNam
 	//If the chat messages starts with the word "repair"
 	if (StrStartsWith(sArgs, "repair"))
 	{	
-		//Get the building the user is asking for
-		int building = GetBuildingByIndexEx(sArgs);
-		int compass = GetCompassByIndex(sArgs);
-		int location = GetSpotByIndex(sArgs);
-		
-		bool foundCompass = foundInChatMessage(compass);
-		bool foundLocation = foundInChatMessage(location);
-		
-		//If a valid building name or alasis is found
-		if (foundInChatMessage(building))
-		{
-			// if building + compass name is found
-			if (foundCompass)
-			{			
-				// if building + compass + location name is found
-				if (foundLocation)
-				{
-					PrintExtendedRepairRequest(	team, pName,
-									nd_request_building[building], 
-									nd_request_compass[compass], 
-									nd_request_location[location]);
-					return true;
-				}
-				
-				Print_CompassBuilding_RepairRequest(	team, pName, 
-									nd_request_building[building], 
-									nd_request_compass[compass]);
-				return true;
-			}
-			
-			// if building + location name is found
-			else if (foundLocation)
-			{
-				Print_LocationBuilding_RepairRequest(	team, pName, 
-									nd_request_building[building], 
-									nd_request_location[location]);
-				return true;			
-			}
-			
-			// if just the building name is found
-			PrintBuildingRepairRequest(team, pName, nd_request_building[building]);
-			return true;
-		}
-		// if compass name is found
-		else if (foundCompass)
-		{
-			// if compass + location name is found
-			if (foundLocation)
-			{
-				Print_CompassLocation_RepairRequest(	team, pName, 
-									nd_request_compass[compass], 
-									nd_request_location[location]);
-				return true;
-			}
-			
-			//if just the compass name is found
-			PrintCompassRepairRequest(team, pName, nd_request_compass[compass]);
-			return true;
-		}
-		// if just the location name is found
-		else if (foundLocation)
-		{
-			PrintLocationRepairRequest(team, pName, nd_request_location[location]);
-			return true;		
-		}			
-		
-		// if no repair keywords are found
-		NoTranslationFound(client, sArgs);
+		repPrintMessage(client, team, pName, sArgs);
 		return true;
 	}	
 		
 	return false;
 }
 
-void PrintBuildingRepairRequest(int team, const char[] pName, const char[] bName)
+void repPrintMessage(int client, int team, const char[] pName, const char[] sArgs)
 {
-	LOOP_TEAM(idx, team) 
+	//Get the building the user is asking for
+	int building = GetBuildingByIndexEx(sArgs);
+	int compass = GetCompassByIndex(sArgs);
+	int location = GetSpotByIndex(sArgs);
+		
+	bool foundCompass = foundInChatMessage(compass);
+	bool foundLocation = foundInChatMessage(location);
+		
+	// if a valid building name or alasis is found
+	if (foundInChatMessage(building))
 	{
-		char building[64];
-		Format(building, sizeof(building), "%T", bName, idx);
-				
-		char ToPrint[128];
-		Format(ToPrint, sizeof(ToPrint), "%T", "Building Repair Request", idx, building);
+		// if building + compass name is found
+		if (foundCompass)
+		{			
+			// if building + compass + location name is found
+			if (foundLocation)
+				NDPC_PrintRequestS3(team, pName, "Extended Repair Request",
+								nd_request_building[building], 
+								nd_request_compass[compass], 
+								nd_request_location[location]);
+			else				
+				NDPC_PrintRequestS2(team, pName, "Build Comp Repair Request", 
+								nd_request_building[building], 
+								nd_request_compass[compass]);	
+		}
 			
-		NDPC_PrintToChat(idx, pName, ToPrint); 		
-	}
-}
-
-void Print_CompassBuilding_RepairRequest(int team, const char[] pName, const char[] bName, const char[] cName)
-{
-	LOOP_TEAM(idx, team) 
-	{			
-		char building[64];
-		Format(building, sizeof(building), "%T", bName, idx);
-			
-		char compass[64];
-		Format(compass, sizeof(compass), "%T", cName, idx);
-		
-		char ToPrint[128];
-		Format(ToPrint, sizeof(ToPrint), "%T", "Build Comp Repair Request", idx, compass, building);
-			
-		NDPC_PrintToChat(idx, pName, ToPrint); 		
+		// if building + location name is found
+		else if (foundLocation)
+			NDPC_PrintRequestS2(team, pName, "Build Loc Repair Request",
+							nd_request_building[building], 
+							nd_request_location[location]);					
+		// if just the building name is found
+		else			
+			NDPC_PrintRequestS1(team, pName, "Building Repair Request",
+							nd_request_building[building]);
 	}	
-}
-
-void PrintCompassRepairRequest(int team, const char[] pName, const char[] cName)
-{
-	LOOP_TEAM(idx, team) 
-	{				
-		char compass[64];
-		Format(compass, sizeof(compass), "%T", cName, idx);
-				
-		char ToPrint[128];
-		Format(ToPrint, sizeof(ToPrint), "%T", "Compass Repair Request", idx, compass);
-				
-		NDPC_PrintToChat(idx, pName, ToPrint); 		
-	}	
-}
-
-void Print_CompassLocation_RepairRequest(int team, const char[] pName, const char[] cName, const char[] lName)
-{
-	LOOP_TEAM(idx, team) 
-	{				
-		char compass[64];
-		Format(compass, sizeof(compass), "%T", cName, idx);
-				
-		char location[64];
-		Format(location, sizeof(location), "%T", lName, idx);
-				
-		char ToPrint[128];
-		Format(ToPrint, sizeof(ToPrint), "%T", "Comp Loc Repair Request", idx, compass, location);
-				
-		NDPC_PrintToChat(idx, pName, ToPrint); 		
-	}
-}
-
-void PrintLocationRepairRequest(int team, const char[] pName, const char[] lName)
-{
-	LOOP_TEAM(idx, team) 
-	{			
-		char location[64];
-		Format(location, sizeof(location), "%T", lName, idx);
-			
-		char ToPrint[128];
-		Format(ToPrint, sizeof(ToPrint), "%T", "Location Repair Request", idx, location);
-				
-		NDPC_PrintToChat(idx, pName, ToPrint); 		
-	}	
-}
-
-void Print_LocationBuilding_RepairRequest(int team, const char[] pName, const char[] bName, const char[] lName)
-{
-	LOOP_TEAM(idx, team) 
-	{			
-		char building[64];
-		Format(building, sizeof(building), "%T", bName, idx)				
-				
-		char location[64];
-		Format(location, sizeof(location), "%T", lName, idx);
-				
-		char ToPrint[128];
-		Format(ToPrint, sizeof(ToPrint), "%T", "Build Loc Repair Request", idx, building, location);
-				
-		NDPC_PrintToChat(idx, pName, ToPrint); 		
-	}	
-}
-
-void PrintExtendedRepairRequest(int team, const char[] pName, const char[] bName, const char[] cName, const char[] lName)
-{
-	LOOP_TEAM(idx, team) 
-	{			
-		char building[64];
-		Format(building, sizeof(building), "%T", bName, idx);
-			
-		char compass[64];
-		Format(compass, sizeof(compass), "%T", cName, idx);
-			
-		char location[64];
-		Format(location, sizeof(location), "%T", lName, idx);
-		
-		char ToPrint[128];
-		Format(ToPrint, sizeof(ToPrint), "%T", "Extended Repair Request", idx, building, compass, location);
 	
-		NDPC_PrintToChat(idx, pName, ToPrint); 		
-	}	
+	// if compass name is found
+	else if (foundCompass)
+	{
+		// if compass + location name is found
+		if (foundLocation)
+			NDPC_PrintRequestS2( team, pName, "Comp Loc Repair Request",
+							nd_request_compass[compass], 
+							nd_request_location[location]);
+		//if just the compass name is found
+		else			
+			NDPC_PrintRequestS1(team, pName, "Compass Repair Request",
+							nd_request_compass[compass]);
+	}
+	
+	// if just the location name is found
+	else if (foundLocation)
+		NDPC_PrintRequestS1(team, pName, "Location Repair Request",
+						nd_request_location[location]);
+	// if no repair keywords are found
+	else
+		NoTranslationFound(client, sArgs);		
 }

--- a/addons/sourcemod/scripting/ndpc/requests/research_req.sp
+++ b/addons/sourcemod/scripting/ndpc/requests/research_req.sp
@@ -13,33 +13,22 @@ bool CheckResearchRequest(int client, int team, int spacesCount, const char[] pN
 	//If the chat messages starts with the word "research"
 	if (StrStartsWith(sArgs, "research"))
 	{	
-		//Get the research the user is asking for
-		int research = GetResearchByIndex(sArgs);
-		
-		//If a valid research name or alasis is found
-		if (foundInChatMessage(research))
-		{
-			PrintSimpleResearchRequest(team, pName, nd_request_research[research]);
-			return true;
-		}
-		
-		NoTranslationFound(client, sArgs);
+		resPrintMessage(client, team, pName, sArgs);
 		return true;
 	}	
 		
 	return false;
 }
 
-void PrintSimpleResearchRequest(int team, const char[] pName, const char[] rName)
+void resPrintMessage(int client, int team, const char[] pName, const char[] sArgs)
 {
-	LOOP_TEAM(idx, team) 
-	{
-		char research[64];
-		Format(research, sizeof(research), "%T", rName, idx);
-				
-		char ToPrint[128];
-		Format(ToPrint, sizeof(ToPrint), "%T", "Simple Research Request", idx, research);
-			
-		NDPC_PrintToChat(idx, pName, ToPrint);		
-	}
+	//Get the research the user is asking for
+	int research = GetResearchByIndex(sArgs);
+		
+	//If a valid research name or alasis is found
+	if (foundInChatMessage(research))
+		NDPC_PrintRequestS1(team, pName, "Simple Research Request", 
+						nd_request_research[research]);
+	else
+		NoTranslationFound(client, sArgs);
 }


### PR DESCRIPTION
- Use trans string and print request functions.
- Don't create new voids for each print request anymore.