### PR TITLE
Setup new troop count version

### DIFF
--- a/addons/sourcemod/scripting/include/nd_breakdown.inc
+++ b/addons/sourcemod/scripting/include/nd_breakdown.inc
@@ -3,14 +3,14 @@
 #endif
 #define _nd_breakdown_included
 
-enum ClassBreakdown
+enum ND_ClassBreakdown
 {
-	DirectCombat = 0,
-	Snipers,
-	AntiStructure,
-	Stealth,
-	Medic,
-	Engineer
+	uCombat = 0,
+	uSnipers,
+	uAntiStructure,
+	uStealth,
+	uMedic,
+	uEngineer
 }
 
 /**

--- a/addons/sourcemod/scripting/nd_team_breakdown.sp
+++ b/addons/sourcemod/scripting/nd_team_breakdown.sp
@@ -34,7 +34,7 @@ public Plugin myinfo =
 	name = "[ND] Team Breakdown",
 	author = "databomb, stickz",
 	description = "Provides troop count display",
-    version = "dummy",
+    	version = "dummy",
 	url = "https://github.com/stickz/Redstone/"
 }
 
@@ -94,7 +94,7 @@ public Action DisplayBreakdownsCommander(Handle timer, any:Userid)
 	int clientTeam = GetClientTeam(client);	
 	if (clientTeam > 1)
 	{
-		if (ND_IsCommanderOnTeam(client, clientTeam)) //commander troops counts
+		if (ND_GetCommanderOnTeam(clientTeam) == client) //commander troops counts
 		{
 			ShowTeamBreakdown(client, clientTeam, 1.0, 0.115, 255, 128, 0, 175);
 			return Plugin_Continue;
@@ -135,12 +135,12 @@ void ShowTeamBreakdown(int client, int clientTeam, float x, float y, int r, int 
 	int arrayIdx = clientTeam -2;
 	Handle hHudText = CreateHudSynchronizer();
 	SetHudTextParams(x, y, BREAKDOWN_UPDATE_RATE, r, g, b, a);
-	ShowSyncHudText(client, hHudText, "%t %d\n%t %d\n%t %d\n%t %d\n%t %d\n%t %d",	"Combat", 			g_Layout[arrayIdx][DirectCombat],					
-																					"Anti-Structure",	g_Layout[arrayIdx][AntiStructure], 	
-																					"Sniper", 			g_Layout[arrayIdx][Snipers], 	
-																					"Stealth", 			g_Layout[arrayIdx][Stealth], 	
-																					"Medic", 			g_Layout[arrayIdx][Medic], 			
-																					"Engineer", 		g_Layout[arrayIdx][Engineer]);
+	ShowSyncHudText(client, hHudText, "%t %d\n%t %d\n%t %d\n%t %d\n%t %d\n%t %d",	"Combat",  		g_Layout[arrayIdx][DirectCombat],					
+											"Anti-Structure",	g_Layout[arrayIdx][AntiStructure], 	
+											"Sniper", 		g_Layout[arrayIdx][Snipers], 	
+											"Stealth", 		g_Layout[arrayIdx][Stealth], 	
+											"Medic", 		g_Layout[arrayIdx][Medic], 			
+											"Engineer", 		g_Layout[arrayIdx][Engineer]);
 	CloseHandle(hHudText);
 }
 

--- a/addons/sourcemod/scripting/nd_unit_limit.sp
+++ b/addons/sourcemod/scripting/nd_unit_limit.sp
@@ -322,7 +322,7 @@ bool IsTooMuchSnipers(int client)
 {
 	int clientTeam = GetClientTeam(client);	
 	int clientCount = ValidTeamCount(client);
-	int sniperCount = GetSniperCount(clientTeam);
+	int sniperCount = NDB_GetUnitCount(clientTeam, uSnipers);
 	int teamIDX = clientTeam - 2;
 
 	if (!SetLimit[teamIDX][TYPE_SNIPER])
@@ -345,7 +345,7 @@ bool IsTooMuchStealth(int client)
 	if (!SetLimit[teamIDX][TYPE_STEALTH])
 		return false;
 		
-	int stealthCount = GetStealthCount(clientTeam);
+	int stealthCount = NDB_GetUnitCount(clientTeam, uStealth);
 	int unitLimit = UnitLimit[teamIDX][TYPE_STEALTH];
 	
 	int stealthMin = GetMinStealthValue(clientTeam);
@@ -362,7 +362,7 @@ bool IsTooMuchAntiStructure(int client)
 	if (!SetLimit[teamIDX][TYPE_STRUCTURE])
 		return false;
 	
-	float AntiStructureFloat = float(GetAntiStructureCount(clientTeam));
+	float AntiStructureFloat = float(NDB_GetUnitCount(clientTeam, uAntiStructure));
 	float teamFloat = float(ValidTeamCount(clientTeam));
 	float AntiStructurePercent = (AntiStructureFloat / teamFloat) * 100.0;
 	

--- a/addons/sourcemod/scripting/nd_unit_limit.sp
+++ b/addons/sourcemod/scripting/nd_unit_limit.sp
@@ -29,6 +29,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <nd_breakdown>
 #include <nd_rounds>
 #include <nd_classes>
+#include <nd_redstone>
 
 #define TYPE_SNIPER 	0
 #define TYPE_STEALTH 	1
@@ -321,7 +322,7 @@ bool IsInvalidTeam(int client, int team)
 bool IsTooMuchSnipers(int client) 
 {
 	int clientTeam = GetClientTeam(client);	
-	int clientCount = ValidTeamCount(client);
+	int clientCount = RED_GetTeamCount(clientTeam);
 	int sniperCount = NDB_GetUnitCount(clientTeam, uSnipers);
 	int teamIDX = clientTeam - 2;
 
@@ -345,13 +346,11 @@ bool IsTooMuchStealth(int client)
 	if (!SetLimit[teamIDX][TYPE_STEALTH])
 		return false;
 		
-	int stealthCount = NDB_GetUnitCount(clientTeam, uStealth);
-	int unitLimit = UnitLimit[teamIDX][TYPE_STEALTH];
-	
+	int unitLimit = UnitLimit[teamIDX][TYPE_STEALTH];	
 	int stealthMin = GetMinStealthValue(clientTeam);
 	int stealthLimit = stealthMin > unitLimit ? stealthMin : unitLimit;
 	
-	return stealthCount >= stealthLimit;
+	return NDB_GetUnitCount(clientTeam, uStealth) >= stealthLimit;
 }
 
 bool IsTooMuchAntiStructure(int client)
@@ -363,7 +362,7 @@ bool IsTooMuchAntiStructure(int client)
 		return false;
 	
 	float AntiStructureFloat = float(NDB_GetUnitCount(clientTeam, uAntiStructure));
-	float teamFloat = float(ValidTeamCount(clientTeam));
+	float teamFloat = float(RED_GetTeamCount(clientTeam));
 	float AntiStructurePercent = (AntiStructureFloat / teamFloat) * 100.0;
 	
 	int percentLimit = UnitLimit[clientTeam - 2][TYPE_STRUCTURE];
@@ -379,7 +378,7 @@ bool IsAntiStructure(int class, int subClass)
 }
 
 int GetMinStealthValue(int team) {
-	return ValidTeamCount(team) < STEALTH_EPLY_COUNT ? MIN_STEALTH_LOW_VALUE : MIN_STEALTH_HIGH_VALUE; 
+	return RED_GetTeamCount(team) < STEALTH_EPLY_COUNT ? MIN_STEALTH_LOW_VALUE : MIN_STEALTH_HIGH_VALUE; 
 }
 
 void ResetPlayerClass(int client) {

--- a/addons/sourcemod/scripting/nd_unit_limit.sp
+++ b/addons/sourcemod/scripting/nd_unit_limit.sp
@@ -323,7 +323,7 @@ bool IsTooMuchSnipers(int client)
 {
 	int clientTeam = GetClientTeam(client);	
 	int clientCount = RED_GetTeamCount(clientTeam);
-	int sniperCount = NDB_GetUnitCount(clientTeam, uSnipers);
+	int sniperCount = NDB_GetUnitCount(clientTeam, view_as<int>(uSnipers));
 	int teamIDX = clientTeam - 2;
 
 	if (!SetLimit[teamIDX][TYPE_SNIPER])
@@ -350,7 +350,7 @@ bool IsTooMuchStealth(int client)
 	int stealthMin = GetMinStealthValue(clientTeam);
 	int stealthLimit = stealthMin > unitLimit ? stealthMin : unitLimit;
 	
-	return NDB_GetUnitCount(clientTeam, uStealth) >= stealthLimit;
+	return NDB_GetUnitCount(clientTeam, view_as<int>(uStealth)) >= stealthLimit;
 }
 
 bool IsTooMuchAntiStructure(int client)
@@ -361,7 +361,7 @@ bool IsTooMuchAntiStructure(int client)
 	if (!SetLimit[teamIDX][TYPE_STRUCTURE])
 		return false;
 	
-	float AntiStructureFloat = float(NDB_GetUnitCount(clientTeam, uAntiStructure));
+	float AntiStructureFloat = float(NDB_GetUnitCount(clientTeam, view_as<int>(uAntiStructure)));
 	float teamFloat = float(RED_GetTeamCount(clientTeam));
 	float AntiStructurePercent = (AntiStructureFloat / teamFloat) * 100.0;
 	


### PR DESCRIPTION
- Use Redstone team count natives (more abstract)

- Use single function instead of multiple to get unit counts.