### PR TITLE
Improve commander checklist plugin

### DIFF
--- a/addons/sourcemod/scripting/include/nd_com_eng.inc
+++ b/addons/sourcemod/scripting/include/nd_com_eng.inc
@@ -6,6 +6,25 @@
 #define NO_COMMANDER -1
 
 /**
+ * Gets if the commander has commander mode.
+ * At least once this round.
+ *
+ * Accepts the input of any client on a team
+ * Then checks if their commander has entered rts_view
+ *
+ * @parm1 clientIDX
+ * @return bool (true, false).
+ */
+
+native bool ND_EnteredCommanderMode(int clientIDX)
+	
+#define ND_ECM_AVAILABLE() (GetFeatureStatus(FeatureType_Native, "ND_EnteredCommanderMode") == FeatureStatus_Available)
+	
+stock bool ND_HasEnteredCommanderMode(int clientIDX) {
+	return ND_ECM_AVAILABLE() && ND_EnteredCommanderMode(clientIDX);
+}
+
+/**
  * Gets if the commander is in commander mode
  *
  * Accepts the input of any client on a team

--- a/addons/sourcemod/scripting/include/nd_com_eng.inc
+++ b/addons/sourcemod/scripting/include/nd_com_eng.inc
@@ -16,7 +16,7 @@
  * @return bool (true, false).
  */
 
-native bool ND_EnteredCommanderMode(int clientIDX)
+native bool ND_EnteredCommanderMode(int clientIDX);
 	
 #define ND_ECM_AVAILABLE() (GetFeatureStatus(FeatureType_Native, "ND_EnteredCommanderMode") == FeatureStatus_Available)
 	

--- a/addons/sourcemod/scripting/nd_commander_checklist.sp
+++ b/addons/sourcemod/scripting/nd_commander_checklist.sp
@@ -116,7 +116,7 @@ public Action OnPlayerChat(Event event, const char[] name, bool dontBroadcast)
 	#endif
 
 	// When the commander chats, check the item off in the list
-	if (ND_IsCommander(client) && ND_IsInCommanderMode(client))
+	if (ND_IsCommander(client) && ND_HasEnteredCommanderMode(client))
 		teamChecklists[GetClientTeam(client)][4] = true;
 
 	return Plugin_Continue;


### PR DESCRIPTION
- Add ND_EnteredCommanderMode() native.
- Reset commander engine variables on map end, in case the round end event is bypassed.
- Change type in chat requirement from being in commander mode to entering it once.