### PR TITLE
Improve nd_bot_features

### DIFF
--- a/addons/sourcemod/scripting/nd_bot_feat/modulus_quota.sp
+++ b/addons/sourcemod/scripting/nd_bot_feat/modulus_quota.sp
@@ -79,7 +79,7 @@ bool ReduceBotCountByMap(const char[] map)
 /* List the really tinny maps to reduce further, (assume default if unlisted) */
 int GetBotReductionCount(const char[] map)
 {
-	if (ND_CustomMapEquals(map, ND_Sanbrick) || ND_CustomMapEquals(map, ND_Mars))
+	if (ND_CustomMapEquals(map, ND_Sandbrick) || ND_CustomMapEquals(map, ND_Mars))
 		return g_cvar[BotReductionDec].IntValue;
 
 	return g_cvar[BotReduction].IntValue;

--- a/addons/sourcemod/scripting/nd_bot_feat/modulus_quota.sp
+++ b/addons/sourcemod/scripting/nd_bot_feat/modulus_quota.sp
@@ -79,8 +79,7 @@ bool ReduceBotCountByMap(const char[] map)
 /* List the really tinny maps to reduce further, (assume default if unlisted) */
 int GetBotReductionCount(const char[] map)
 {
-	if (StrEqual(map, ND_CustomMaps[view_as<int>(ND_Sandbrick)], false)
-	||  StrEqual(map, ND_CustomMaps[view_as<int>(ND_Mars)], false))
+	if (ND_CustomMapEquals(map, ND_Sanbrick) || ND_CustomMapEquals(map, ND_Mars))
 		return g_cvar[BotReductionDec].IntValue;
 
 	return g_cvar[BotReduction].IntValue;
@@ -109,50 +108,18 @@ int GetSmallMapCount(int totalCount, int specCount, int rQuota)
 	return botAmount;
 }
 
-/* Disable bots sonner on certain maps */
-#define SMALL_MAP_SIZE2 2
-int sSM[SMALL_MAP_SIZE2] = {
-	view_as<int>(ND_Silo),
-	view_as<int>(ND_Oilfield)
-}
-
-#define SMALL_MAP_SIZE3 2
-int cSM[SMALL_MAP_SIZE3] = {
-	view_as<int>(ND_Sandbrick),
-	view_as<int>(ND_Corner)
-}
-
-#define LARGE_MAP_SIZE 2
-int lSM[LARGE_MAP_SIZE] = {
-	view_as<int>(ND_Gate),
-	view_as<int>(ND_Downtown)
-};
-
 int GetBotShutOffCount()
 {
 	char map[32];
 	GetCurrentMap(map, sizeof(map));
+
+	// Disable bots sooner if it's a tiny/broken map
+	if (ND_StockMapEquals(map, ND_Oilfield) || ND_CustomMapEquals(map, ND_Sandbrick) || ND_CustomMapEquals(map, ND_Corner))
+		return g_cvar[DisableBotsAtDec].IntValue;
 	
-	/* Look through arrays to see if it's a small/broken stock maps */
-	for (int idx = 0; idx < SMALL_MAP_SIZE2; idx++)
-	{
-		if (StrEqual(map, ND_StockMaps[sSM[idx]], false))
-			return g_cvar[DisableBotsAtDec].IntValue;
-	}
-	
-	/* Look through arrays to see if it's a small/broken custom maps */
-	for (int id = 0; id < SMALL_MAP_SIZE3; id++)
-	{
-		if (StrEqual(map, ND_CustomMaps[cSM[id]], false))
-			return g_cvar[DisableBotsAtDec].IntValue;
-	}
-	
-	/* Look through array to see if it's a large stock map */
-	for (int ix = 0; ix < LARGE_MAP_SIZE; ix++)
-	{
-		if (StrEqual(map, ND_StockMaps[lSM[ix]], false))
-			return g_cvar[DisableBotsAtInc].IntValue;
-	}
+	// Disable bots later if it's a large stock map
+	if (ND_StockMapEquals(map, ND_Gate) || ND_StockMapEquals(map, ND_Downtown))
+		return g_cvar[DisableBotsAtInc].IntValue;
 	
 	/* Otherwise, return the default value */
 	return g_cvar[DisableBotsAt].IntValue;

--- a/addons/sourcemod/scripting/nd_bot_features.sp
+++ b/addons/sourcemod/scripting/nd_bot_features.sp
@@ -98,13 +98,12 @@ void checkCount()
 		{	
 			// Get the bot count to fill empty team slots
 			int dynamicSlots = GetDynamicSlotCount() - 2;
-			int clientCount = RED_ClientCount();
 			
 			// Must use actual team count here to count properly
 			int teamCount = OnTeamCount();			
-			quota = getBotFillerQuota(teamCount, clientCount < dynamicSlots);		
+			quota = getBotFillerQuota(teamCount, GetClientCount() < dynamicSlots);		
 			
-			if (quota >= dynamicSlots && getPositiveOverBalance() >= 3)
+			if (quota >= dynamicSlots && getPositiveOverBalance() >= 2)
 			{
 				quota = getBotFillerQuota(teamCount);	
 			

--- a/addons/sourcemod/scripting/nd_managed_slots.sp
+++ b/addons/sourcemod/scripting/nd_managed_slots.sp
@@ -83,9 +83,9 @@ public void OnClientPutInServer(int client)
 
 public void OnClientAuthorized(int client)
 {	
-	if (!IsFakeClient(client))
+	if (!IsFakeClient(client) && GetClientCount(false) > g_Integer[maxKickCount])
 	{		
-		if (GetClientCount(false) > g_Integer[maxKickCount] && eDynamicSlots)
+		if (eDynamicSlots)
 		{			
 			if (!RED_IsDonator(client))
 				KickClient(client, "%t", "Donors Only");		
@@ -95,6 +95,8 @@ public void OnClientAuthorized(int client)
 				slotUsed[client] = true;
 			}
 		}
+		else
+			g_Integer[maxKickCount]++;
 	}
 }
 

--- a/addons/sourcemod/scripting/nd_managed_slots.sp
+++ b/addons/sourcemod/scripting/nd_managed_slots.sp
@@ -87,16 +87,14 @@ public void OnClientAuthorized(int client)
 	{		
 		if (eDynamicSlots)
 		{			
-			if (!RED_IsDonator(client))
-				KickClient(client, "%t", "Donors Only");		
-			else
+			slotUsed[client] = RED_IsDonator(client);
+			if (!slotUsed[client])
 			{
-				g_Integer[maxKickCount]++;
-				slotUsed[client] = true;
+				KickClient(client, "%t", "Donors Only");
+				return;
 			}
 		}
-		else
-			g_Integer[maxKickCount]++;
+		g_Integer[maxKickCount]++;
 	}
 }
 


### PR DESCRIPTION
- Use new nd_maps.inc version to do some house cleaning

- Silo is fixed, so disable bots normally at 8 players now.

- Use actual client connect to decide of players can connect.

- Boost server slots on two overbalance instead of three.

- Make server slot boosting work properly with the reserved pool.