### PR TITLE
Optimize player skill math calculations

### DIFF
--- a/addons/sourcemod/scripting/include/smlib/math.inc
+++ b/addons/sourcemod/scripting/include/smlib/math.inc
@@ -19,6 +19,10 @@ enum VecAngle
 	ANG_GAMMA
 }
 
+stock int RoundToNearestMultiple(int value, int mult) {
+	return (n + mult -1) / mult * mult;
+}
+
 /**
  * Makes a negative integer number to a positive integer number.
  *

--- a/addons/sourcemod/scripting/include/smlib/math.inc
+++ b/addons/sourcemod/scripting/include/smlib/math.inc
@@ -20,11 +20,11 @@ enum VecAngle
 }
 
 stock int RoundToNearestMultiple(int value, int mult) {
-	return (n + mult -1) / mult * mult;
+	return (value + mult -1) / mult * mult;
 }
 
 stock float RoundToNearestMultipleEx(int value, int mult) {
-	return (n + mult -1) / mult * mult;
+	return (value + mult -1) / mult * mult;
 }
 
 /**

--- a/addons/sourcemod/scripting/include/smlib/math.inc
+++ b/addons/sourcemod/scripting/include/smlib/math.inc
@@ -23,6 +23,10 @@ stock int RoundToNearestMultiple(int value, int mult) {
 	return (n + mult -1) / mult * mult;
 }
 
+stock float RoundToNearestMultipleEx(int value, int mult) {
+	return (n + mult -1) / mult * mult;
+}
+
 /**
  * Makes a negative integer number to a positive integer number.
  *

--- a/addons/sourcemod/scripting/nd_player_skill.sp
+++ b/addons/sourcemod/scripting/nd_player_skill.sp
@@ -8,6 +8,7 @@
 #include <nd_com_eng>
 #include <nd_aweight>
 #include <nd_entities>
+#include <smlib/math>
 
 #define _DEBUG 0
 

--- a/addons/sourcemod/scripting/nd_ply_skill/prediction.sp
+++ b/addons/sourcemod/scripting/nd_ply_skill/prediction.sp
@@ -15,7 +15,6 @@ bool PlayerUnderPerforming(GameMeSkill) {
 	return g_isWeakVeteran[client] && gameMeSkill > lastAverage;
 }
 
-
 float MinSkillValue(int clientLevel, int endLevel = 20, int multiple = 5) {
 	return clientLevel < endLevel ? RoundToNearestMultipleEx(clientLevel, multiple) : float(clientLevel);
 }

--- a/addons/sourcemod/scripting/nd_ply_skill/prediction.sp
+++ b/addons/sourcemod/scripting/nd_ply_skill/prediction.sp
@@ -11,10 +11,6 @@ bool RookieClassify() {
 	return lastAverage < SERVER_IS_ROOKIE;
 }
 
-float RookieMinSkillValue(int clientLevel) {
-	return clientLevel < 10 ? RoundToNearestMultipleEx(clientLevel, 5) : float(clientLevel);
-}
-
 float MinSkillValue(int clientLevel, int endLevel = 20, int multiple = 5) {
 	return clientLevel < endLevel ? RoundToNearestMultipleEx(clientLevel, multiple) : float(clientLevel);
 }

--- a/addons/sourcemod/scripting/nd_ply_skill/prediction.sp
+++ b/addons/sourcemod/scripting/nd_ply_skill/prediction.sp
@@ -11,6 +11,11 @@ bool RookieClassify() {
 	return lastAverage < SERVER_IS_ROOKIE;
 }
 
+bool PlayerUnderPerforming(GameMeSkill) {
+	return g_isWeakVeteran[client] && gameMeSkill > lastAverage;
+}
+
+
 float MinSkillValue(int clientLevel, int endLevel = 20, int multiple = 5) {
 	return clientLevel < endLevel ? RoundToNearestMultipleEx(clientLevel, multiple) : float(clientLevel);
 }

--- a/addons/sourcemod/scripting/nd_ply_skill/prediction.sp
+++ b/addons/sourcemod/scripting/nd_ply_skill/prediction.sp
@@ -11,41 +11,21 @@ bool RookieClassify() {
 	return lastAverage < SERVER_IS_ROOKIE;
 }
 
-float RookieMinSkillValue(int clientLevel)
-{
-	switch (clientLevel)
-	{
-		case 0,1,2,3,4: return 5.0;
-		case 6,7,8,9: return 10.0;
-		default: return float(clientLevel);
-	}
-	
-	return float(REMOVE_COMPILE_WARNING); //This code isn't accessible
+float RookieMinSkillValue(int clientLevel) {
+	return clientLevel < 10 ? RoundToNearestMultipleEx(clientLevel, 5) : float(clientLevel);
 }
 
-float MinSkillValue(int clientLevel)
-{
-	switch (clientLevel)
-	{
-		case 0,1,2,3,4,5,6,7,8,9,10: return 10.0;
-		case 11,12,13,14,15: return 15.0;
-		case 16,17,18,19,20: return 20.0;
-		default: return float(clientLevel);
-	}
-	
-	return float(REMOVE_COMPILE_WARNING); //This code isn't accessible
+float MinSkillValue(int clientLevel) {
+	return clientLevel < 20 ? RoundToNearestMultipleEx(clientLevel, 5) : float(clientLevel);
 }
 
 float PredictedSkill(int clientLevel)
 {
 	/* Predict to increase accuracy of players lacking data
 	 * int players are worth 4 average players
-	 * Semi-int players are worth 2.75 average players
+	 * Semi-int players are worth 3 average players
 	 * Otherwise, use the client level for regular clients.
-	 */	
-	
+	 */
 	float min = lastAverage / 4.25;
-	float max = lastAverage / 3.0;
-						
-	return clientLevel < min ? min : clientLevel < max ? max : float(clientLevel);
+	return clientLevel < min ? min : Math_Max(clientLevel, lastAverage / 3);
 }

--- a/addons/sourcemod/scripting/nd_ply_skill/prediction.sp
+++ b/addons/sourcemod/scripting/nd_ply_skill/prediction.sp
@@ -15,8 +15,8 @@ float RookieMinSkillValue(int clientLevel) {
 	return clientLevel < 10 ? RoundToNearestMultipleEx(clientLevel, 5) : float(clientLevel);
 }
 
-float MinSkillValue(int clientLevel) {
-	return clientLevel < 20 ? RoundToNearestMultipleEx(clientLevel, 5) : float(clientLevel);
+float MinSkillValue(int clientLevel, int endLevel = 20, int multiple = 5) {
+	return clientLevel < endLevel ? RoundToNearestMultipleEx(clientLevel, multiple) : float(clientLevel);
 }
 
 float PredictedSkill(int clientLevel)

--- a/addons/sourcemod/scripting/nd_ply_skill/prediction.sp
+++ b/addons/sourcemod/scripting/nd_ply_skill/prediction.sp
@@ -11,7 +11,7 @@ bool RookieClassify() {
 	return lastAverage < SERVER_IS_ROOKIE;
 }
 
-bool PlayerUnderPerforming(GameMeSkill) {
+bool PlayerUnderPerforming(int client, float gameMeSkill) {
 	return g_isWeakVeteran[client] && gameMeSkill > lastAverage;
 }
 

--- a/addons/sourcemod/scripting/nd_ply_skill/prediction.sp
+++ b/addons/sourcemod/scripting/nd_ply_skill/prediction.sp
@@ -27,5 +27,5 @@ float PredictedSkill(int clientLevel)
 	 * Otherwise, use the client level for regular clients.
 	 */
 	float min = lastAverage / 4.25;
-	return clientLevel < min ? min : Math_Max(clientLevel, lastAverage / 3);
+	return clientLevel < min ? min : Math_Max(clientLevel, lastAverage / 3.0);
 }

--- a/addons/sourcemod/scripting/nd_ply_skill/skill_calc.sp
+++ b/addons/sourcemod/scripting/nd_ply_skill/skill_calc.sp
@@ -38,18 +38,15 @@ float GetSkillLevel(int client)
 			return cachedAverage;	
 	}
 
+	if (EnableSkillPrediction())
+		return PredictedSkill(clientLevel);
+		
 	/* Then try to use the client level */
 	if (clientLevel >= 20)
 		return float(clientLevel);
-	
-	/* If that is too low, set skill to min threshold */				
-	if (RookieClassify())
-		return RookieMinSkillValue(clientLevel);
-				
-	if (EnableSkillPrediction())
-		return PredictedSkill(clientLevel);				
-			
-	return MinSkillValue(clientLevel);
+		
+	/* If that is too low, set skill to min threshold */	
+	return MinSkillValue(clientLevel, RookieClassify() ? 10 : 20);
 }
 
 float GetCommanderSkill(int client)

--- a/addons/sourcemod/scripting/nd_ply_skill/skill_calc.sp
+++ b/addons/sourcemod/scripting/nd_ply_skill/skill_calc.sp
@@ -41,11 +41,7 @@ float GetSkillLevel(int client)
 	if (EnableSkillPrediction())
 		return PredictedSkill(clientLevel);
 		
-	/* Then try to use the client level */
-	if (clientLevel >= 20)
-		return float(clientLevel);
-		
-	/* If that is too low, set skill to min threshold */	
+	// Return a min skill multiple or the client level (whichever is greater)
 	return MinSkillValue(clientLevel, RookieClassify() ? 10 : 20);
 }
 

--- a/addons/sourcemod/scripting/nd_ply_skill/skill_calc.sp
+++ b/addons/sourcemod/scripting/nd_ply_skill/skill_calc.sp
@@ -4,27 +4,12 @@ float GetSkillLevel(int client)
 	int clientLevel = getClientLevel(client);
 	int skillFloor = ND_GetSkillFloor(client);
 	
-	/* Try to use the gameme skill value first */
+	// If the gameme player skill is found...
+	// If the player is under-performing, set their skill to the average		
+	// Otherwise, return the max of the clientLevel, gameMeSkill or Skill Floor
 	float gameMeSkill = GameME_PlayerSkill[client];
 	if (gameMeSkill > -1)
-	{
-		/* If the player is under-performing, lower their skill */
-		if (g_isWeakVeteran[client] && gameMeSkill > lastAverage)
-			gameMeSkill = lastAverage;
-		else
-		{
-			/* Enforce of min skill of clientLevel * 0.8 */
-			float minSkill = clientLevel * 0.8;
-			if (gameMeSkill < minSkill)
-				gameMeSkill = minSkill;
-			
-			/* Or Enforce a min skill of the set floor */
-			else if (gameMeSkill < skillFloor)
-				gameMeSkill = float(skillFloor);
-		}
-			
-		return gameMeSkill;			
-	}
+		return PlayerUnderPerforming(gameMeSkill) ? lastAverage : Math_Max(Math_Max(gameMeSkill, clientLevel), skillFloor);		
 	
 	/* Then check if a client has a skill floor */
 	if (skillFloor != -1)
@@ -51,30 +36,15 @@ float GetCommanderSkill(int client)
 	int clientLevel = getClientLevel(client);
 	int skillFloor = ND_GetSkillFloor(client);
 	
-	/* Try to use the gameme skill value first */
+	// If the gameme commander skill is found... 
+	// Return the max of the clientLevel, GameMeCommSkill or Skill Floor
 	float gameMeComSkill = GameME_CommanderSkill[client];
 	if (gameMeComSkill > -1)
-	{
-		/* Enforce of min skill of clientLevel */
-		if (gameMeComSkill < clientLevel)
-			gameMeComSkill = float(clientLevel);
-			
-		/* Or Enforce a min skill of the set floor */
-		else if (gameMeComSkill < skillFloor)
-			gameMeComSkill = float(skillFloor);
-		
-		return gameMeComSkill;
-	}
-	
-	/* Then check if a client has a skill floor */
-	if (skillFloor != -1)
-		return float(skillFloor);
-	
-	/* Then try to use the client level */
-	if (clientLevel >= 20)
-		return float(clientLevel);
-	
-	return MinSkillValue(clientLevel);
+		return Math_Max(Math_Max(gameMeComSkill, clientLevel), skillFloor);
+
+	// If the client has a skill floor then return that otherwise...
+	// Return a min skill multiple or the client level (whichever is greater)
+	return skillFloor != -1 ? float(skillFloor) : MinSkillValue(clientLevel, 30);
 }
 
 void UpdateSkillAverage()

--- a/addons/sourcemod/scripting/nd_ply_skill/skill_calc.sp
+++ b/addons/sourcemod/scripting/nd_ply_skill/skill_calc.sp
@@ -9,7 +9,8 @@ float GetSkillLevel(int client)
 	// Otherwise, return the max of the clientLevel, gameMeSkill or Skill Floor
 	float gameMeSkill = GameME_PlayerSkill[client];
 	if (gameMeSkill > -1)
-		return PlayerUnderPerforming(gameMeSkill) ? lastAverage : Math_Max(Math_Max(gameMeSkill, clientLevel), skillFloor);		
+		return 	PlayerUnderPerforming(client, gameMeSkill) ? lastAverage : 
+			Math_Max(Math_Max(gameMeSkill, clientLevel), skillFloor);		
 	
 	/* Then check if a client has a skill floor */
 	if (skillFloor != -1)


### PR DESCRIPTION
- Reduce the overhead in calculating player and commander skill.

- Make it work better by fixing a few minor bugs with skill prediction.

- Round up in multiples of 5 bellow 30 instead of 20 for commander skill.