### PR TITLE
Reload team-picker on map change

### DIFF
--- a/addons/sourcemod/scripting/nd_team_pick/commands.sp
+++ b/addons/sourcemod/scripting/nd_team_pick/commands.sp
@@ -21,7 +21,7 @@ public Action ReloadTeamPicker(int client, int args)
 	DisplayReloadedPlugin(client);
 	
 	// Reload the team picking plugin
-	ServerCommand("sm plugins reload nd_team_picking");	
+	ReloadThePlugin();	
 	return Plugin_Handled;
 }
 
@@ -30,6 +30,10 @@ void DisplayReloadedPlugin(int client)
 	char Name[32];
 	GetClientName(client, Name, sizeof(Name));	
 	PrintToChatAll("\x05[xG] %s reloaded the team picker plugin!", Name);
+}
+
+void ReloadThePlugin() {
+	ServerCommand("sm plugins reload nd_team_picking");
 }
 
 public Action DisableTeamChg(int client, intargs) 

--- a/addons/sourcemod/scripting/nd_team_picking.sp
+++ b/addons/sourcemod/scripting/nd_team_picking.sp
@@ -56,6 +56,10 @@ public void OnPluginStart()
 	AddUpdaterLibrary(); //auto-updater
 }
 
+public void OnMapStart() {
+	ReloadThePlugin();
+}
+
 public Action Command_JoinTeam(int client, char[] command, int argc)
 {
 	if (!ND_RoundStarted() && g_bEnabled)


### PR DESCRIPTION
- Reset plugin state back to default to fix bugs with various things like team-locking.