### PR TITLE
Improve server slot config

### DIFF
--- a/addons/sourcemod/scripting/nd_slots/thresholds.sp
+++ b/addons/sourcemod/scripting/nd_slots/thresholds.sp
@@ -14,14 +14,11 @@ int GetMapPlayerCount(const char[] checkMap)
 		return GetSlotCount(26, 28, 30);	
 	}
 	
-	if (largeMap)
-		return GetSlotCount(26, 30, 30);
+	if (largeMap || ND_IsMediumMap(checkMap))
+		return GetSlotCount(26, 28, 28);
 		
 	else if (tinyMap)
 		return GetSlotCount(22, 26, 26);
-		
-	else if (ND_IsMediumMap(checkMap))
-		return GetSlotCount(26, 28, 30);
 
 	/* metro, silo, oasis, coast, hydro, roadwork */
 	return GetSlotCount(24, 28, 28);

--- a/addons/sourcemod/scripting/nd_slots/thresholds.sp
+++ b/addons/sourcemod/scripting/nd_slots/thresholds.sp
@@ -20,8 +20,8 @@ int GetMapPlayerCount(const char[] checkMap)
 	else if (tinyMap)
 		return GetSlotCount(22, 26, 26);
 
-	/* metro, silo, oasis, coast, hydro, roadwork */
-	return GetSlotCount(24, 28, 28);
+	/* oasis, coast, hydro, roadwork */
+	return GetSlotCount(24, 26, 28);
 }
 
 bool ND_IsLargeMap(const char[] checkMap)

--- a/addons/sourcemod/scripting/nd_slots/thresholds.sp
+++ b/addons/sourcemod/scripting/nd_slots/thresholds.sp
@@ -21,7 +21,7 @@ int GetMapPlayerCount(const char[] checkMap)
 		return GetSlotCount(22, 26, 26);
 		
 	else if (ND_IsMediumMap(checkMap))
-		return GetSlotCount(24, 28, 30);
+		return GetSlotCount(26, 28, 30);
 
 	/* metro, silo, oasis, coast, hydro, roadwork */
 	return GetSlotCount(24, 28, 28);
@@ -38,7 +38,9 @@ bool ND_IsLargeMap(const char[] checkMap)
 bool ND_IsMediumMap(const char[] checkMap)
 {
 	return ND_StockMapEquals(checkMap, ND_Clocktower)
-		|| ND_CustomMapEquals(checkMap, ND_Nuclear);	
+		|| ND_CustomMapEquals(checkMap, ND_Nuclear)
+		|| ND_CustomMapEquals(checkMap, ND_MetroImp)
+		|| ND_StockMapEquals(checkMap, ND_Silo);
 }
 
 bool ND_IsTinyMap(const char[] checkMap)


### PR DESCRIPTION
- Limit max server slots to 28 from 30 due to server hosting changes.

- Change regular medium slots from 28 to 26.

- Reclassify metro and silo as medium maps due to added ternary scaling.

- Increase medium map server slot min from 24 to 26.