### PR TITLE
Restrict event-hoster access to commands

### DIFF
--- a/addons/sourcemod/scripting/include/nd_warmup.inc
+++ b/addons/sourcemod/scripting/include/nd_warmup.inc
@@ -9,6 +9,6 @@ native bool ND_WarmupCompleted();
 native bool ND_TeamPickMode();
 #define ND_TPM_AVAILABLE() (GetFeatureStatus(FeatureType_Native, "ND_TeamPickMode") == FeatureStatus_Available)
 
-stock bool IsTeamPickRunning(bool default = true) {
-	return !ND_TPM_AVAILABLE() ? default : ND_TeamPickMode();
+stock bool IsTeamPickRunning() {
+	return !ND_TPM_AVAILABLE() ? true : ND_TeamPickMode();
 }

--- a/addons/sourcemod/scripting/include/nd_warmup.inc
+++ b/addons/sourcemod/scripting/include/nd_warmup.inc
@@ -14,5 +14,5 @@ stock bool IsTeamPickRunning() {
 }
 
 stock bool HasTeamPickAccess(int client) {
-	return IsTeamPickRunning() || GetAdminFlag(client, Admin_Root, Access_Real);
+	return IsTeamPickRunning() || GetAdminFlag(GetUserAdmin(client), Admin_Root, Access_Real);
 }

--- a/addons/sourcemod/scripting/include/nd_warmup.inc
+++ b/addons/sourcemod/scripting/include/nd_warmup.inc
@@ -8,3 +8,7 @@ native bool ND_WarmupCompleted();
 /* Ask the warmup plugin if TeamPick mode is running */
 native bool ND_TeamPickMode();
 #define ND_TPM_AVAILABLE() (GetFeatureStatus(FeatureType_Native, "ND_TeamPickMode") == FeatureStatus_Available)
+
+stock bool IsTeamPickRunning(bool default = true) {
+	return !ND_TPM_AVAILABLE() ? default : ND_TeamPickMode();
+}

--- a/addons/sourcemod/scripting/include/nd_warmup.inc
+++ b/addons/sourcemod/scripting/include/nd_warmup.inc
@@ -12,3 +12,7 @@ native bool ND_TeamPickMode();
 stock bool IsTeamPickRunning() {
 	return !ND_TPM_AVAILABLE() ? true : ND_TeamPickMode();
 }
+
+stock bool HasTeamPickAccess(int client) {
+	return IsTeamPickRunning() || GetAdminFlag(client, Admin_Root, Access_Real);
+}

--- a/addons/sourcemod/scripting/nd_commander_actions.sp
+++ b/addons/sourcemod/scripting/nd_commander_actions.sp
@@ -68,10 +68,10 @@ public OnAdminMenuReady(Handle:topmenu)
 
 public Action Cmd_SetCommander(int client, int args)
 {
-	if (!HasTeamPickAccess())
+	if (!HasTeamPickAccess(client))
 	{
 		ReplyToCommand(client, "[SM] You only have team-pick access to this command!");
-		return Plugin_Handled;	
+		return Plugin_Handled;
 	}
 	
 	if (!args)
@@ -97,10 +97,10 @@ public Action Cmd_SetCommander(int client, int args)
 
 public Action Cmd_Demote(int client, int args)
 {
-	if (!HasTeamPickAccess())
+	if (!HasTeamPickAccess(client))
 	{
 		ReplyToCommand(client, "[SM] You only have team-pick access to this command!");
-		return Plugin_Handled;	
+		return Plugin_Handled;
 	}
 	
 	if (!args)

--- a/addons/sourcemod/scripting/nd_commander_actions.sp
+++ b/addons/sourcemod/scripting/nd_commander_actions.sp
@@ -17,6 +17,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include <sourcemod>
 #include <sdktools>
 #include <adminmenu>
+#include <nd_warmup>
 
 public Plugin myinfo =
 {
@@ -67,6 +68,12 @@ public OnAdminMenuReady(Handle:topmenu)
 
 public Action Cmd_SetCommander(int client, int args)
 {
+	if (!HasTeamPickAccess())
+	{
+		ReplyToCommand(client, "[SM] You only have team-pick access to this command!");
+		return Plugin_Handled;	
+	}
+	
 	if (!args)
 	{
 		ReplyToCommand(client, "[SM] Usage: sm_setcommander <Name|#Userid>");
@@ -90,6 +97,12 @@ public Action Cmd_SetCommander(int client, int args)
 
 public Action Cmd_Demote(int client, int args)
 {
+	if (!HasTeamPickAccess())
+	{
+		ReplyToCommand(client, "[SM] You only have team-pick access to this command!");
+		return Plugin_Handled;	
+	}
+	
 	if (!args)
 	{
 		ReplyToCommand(client, "[SM] Usage: sm_demotecommander <ct | emp>");

--- a/addons/sourcemod/scripting/nd_rockthevote.sp
+++ b/addons/sourcemod/scripting/nd_rockthevote.sp
@@ -16,6 +16,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 #include <mapchooser>
 #include <nextmap>
+#include <nd_warmup>
 
 // Hack - Too lazy to create include file
 native bool ND_TriggerMapVote();
@@ -31,7 +32,6 @@ native bool ND_TriggerMapVote();
 #include <nd_redstone>
 #include <nd_print>
 #include <nd_maps>
-#include <nd_warmup>
 #include <mapchooser>
 
 enum Bools

--- a/addons/sourcemod/scripting/nd_warmup.sp
+++ b/addons/sourcemod/scripting/nd_warmup.sp
@@ -30,7 +30,8 @@ enum Bools
 	runBalancer,
 	enableBalancer,
 	pauseWarmup,
-	warmupCompleted
+	warmupCompleted,
+	currentlyPicking
 };
 
 enum Integers
@@ -230,7 +231,10 @@ void SetWarmupEndType()
 		ServerCommand("sm_balance 0"); // Disable team balancer plugin
 		ServerCommand("sm_commander_restrictions 0"); // Disable commander restrictions
 		ServerCommand("sm_cvar nd_commander_election_time 15.0");
-		PrintToAdmins("\x05[xG] Team Picking is now availible!", "b");
+		
+		g_Bool[currentlyPicking] = true;
+		PrintToAdmins("\x05[xG] Team Picking is now availible!", "b");		
+		
 		FireWarmupCompleteForward();
 		
 		return;
@@ -288,6 +292,7 @@ void SetVarDefaults()
 	g_Bool[useBalancer] = false;
 	g_Bool[runBalancer] = true;
 	g_Bool[warmupCompleted] = false;
+	g_Bool[currentlyPicking] = false;
 	g_Bool[enableBalancer] = g_Cvar[enableWarmupBalance].BoolValue;
 	g_Integer[warmupTextType] = 0;
 }
@@ -317,5 +322,5 @@ public Native_GetWarmupCompleted(Handle plugin, int numParms) {
 }
 
 public Native_GetTeamPickMode(Handle plugin, int numParms) {
-	return _:g_Bool[pauseWarmup];
+	return _:g_Bool[currentlyPicking];
 }


### PR DESCRIPTION
- Rework warmup plugin to better check if team-pick is running.

- Restrict access to commander demote & promote to warmup only (for non-root clients)

- Restrict access to team-change commands to warmup only (for non-root clients)