### PR TITLE
Improve pull bot plugin

### DIFF
--- a/addons/sourcemod/scripting/nd_pull_bot.sp
+++ b/addons/sourcemod/scripting/nd_pull_bot.sp
@@ -3,6 +3,7 @@
 #include <nd_stocks>
 #include <nd_entities>
 #include <nd_stype>
+#include <nd_print>
 
 #define INVALID_USERID 0
 

--- a/addons/sourcemod/scripting/nd_pull_bot.sp
+++ b/addons/sourcemod/scripting/nd_pull_bot.sp
@@ -40,7 +40,7 @@ public void OnPluginStart()
 	if (ND_GetServerTypeEx(ND_SType_Stable) == SERVER_TYPE_ALPHA)
 		RegBotGroundCheck(); // for ground_check.sp
 	
-	LoadTranslations(nd_pull_bot.phrases"); // Translated messages	
+	LoadTranslations("nd_pull_bot.phrases"); // Translated messages	
 	AutoExecConfig(true, "nd_pull_bot"); // for convars
 	AddUpdaterLibrary(); //auto-updater
 }

--- a/addons/sourcemod/scripting/nd_pull_bot.sp
+++ b/addons/sourcemod/scripting/nd_pull_bot.sp
@@ -40,6 +40,7 @@ public void OnPluginStart()
 	if (ND_GetServerTypeEx(ND_SType_Stable) == SERVER_TYPE_ALPHA)
 		RegBotGroundCheck(); // for ground_check.sp
 	
+	LoadTranslations(nd_pull_bot.phrases"); // Translated messages	
 	AutoExecConfig(true, "nd_pull_bot"); // for convars
 	AddUpdaterLibrary(); //auto-updater
 }

--- a/addons/sourcemod/scripting/nd_pull_bot.sp
+++ b/addons/sourcemod/scripting/nd_pull_bot.sp
@@ -15,6 +15,12 @@ public Plugin myinfo =
     url = "https://github.com/stickz/Redstone"
 };
 
+/* Convars for Plugin */
+ConVar gCheck_BunkerDistance;
+ConVar gCheck_SpawnDelay;
+ConVar mBot_MaxDistance;
+ConVar mBot_RetryDelay;
+
 // Module 1: Allow players to pull bots toward them
 #include "nd_pull_bot/move_bot.sp"
 
@@ -33,6 +39,7 @@ public void OnPluginStart()
 	if (ND_GetServerTypeEx(ND_SType_Stable) == SERVER_TYPE_ALPHA)
 		RegBotGroundCheck(); // for ground_check.sp
 	
+	AutoExecConfig(true, "nd_pull_bot"); // for convars
 	AddUpdaterLibrary(); //auto-updater
 }
 
@@ -42,4 +49,12 @@ public void ND_OnRoundStarted() {
 
 public void OnClientConnected(int client) {
 	CanPullBot[client] = true;
+}
+
+void CreatePluginConvars()
+{
+	gCheck_BunkerDistance	= CreateConVar("sm_gcheck_bdistance", "1500", "Distance away from bunker spawn must be to use feature");
+	gCheck_SpawnDelay 	= CreateConVar("sm_gcheck_sdelay", "8", "Delay after spawning to perform bot ground check");
+	mBot_MaxDistance	= CreateConVar("sm_mbot_bdistance", "300", "Distance player must be away from bot to pull them");
+	mBot_RetryDelay		= CreateConVar("sm_mbot_bdistance", "8", "Delay player must wait before performing pulls");
 }

--- a/addons/sourcemod/scripting/nd_pull_bot.sp
+++ b/addons/sourcemod/scripting/nd_pull_bot.sp
@@ -30,8 +30,16 @@ public void OnPluginStart()
 	RegPullBotCommand(); // for move_bot.sp
 	
 	// Only enable ground checks on the alpha server for now
-	if (ND_GetServerTypeEx(ND_SType_Alpha) == SERVER_TYPE_ALPHA)
+	if (ND_GetServerTypeEx(ND_SType_Stable) == SERVER_TYPE_ALPHA)
 		RegBotGroundCheck(); // for ground_check.sp
 	
 	AddUpdaterLibrary(); //auto-updater
+}
+
+public void ND_OnRoundStarted() {
+	ResetPullCooldowns(); // for move_bot.sp
+}
+
+public void OnClientConnected(int client) {
+	CanPullBot[client] = true;
 }

--- a/addons/sourcemod/scripting/nd_pull_bot/ground_check.sp
+++ b/addons/sourcemod/scripting/nd_pull_bot/ground_check.sp
@@ -1,5 +1,6 @@
 float coords[MAXPLAYERS+1][2];
 #define fMaxBunkerDistance 1500.0
+#define GROUND_CHECK_DELAY 8.0
 
 void RegBotGroundCheck() {
 	HookEvent("player_spawn", OnPlayerSpawn, EventHookMode_PostNoCopy);
@@ -19,8 +20,8 @@ public Action OnPlayerSpawn(Event event, const char[] name, bool dontBroadcast)
 		coords[client][0] = pos[0];
 		coords[client][1] = pos[1];
 		
-		// Check in three seconds if the bot is stuck
-		CreateTimer(3.0, Timer_CheckBot, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE);
+		// Wait 8 seconds before checking, so bots can capture resources (if required)
+		CreateTimer(GROUND_CHECK_DELAY, Timer_CheckBot, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE);
 	}
 	
 	return Plugin_Continue;

--- a/addons/sourcemod/scripting/nd_pull_bot/ground_check.sp
+++ b/addons/sourcemod/scripting/nd_pull_bot/ground_check.sp
@@ -1,6 +1,4 @@
 float coords[MAXPLAYERS+1][2];
-#define fMaxBunkerDistance 1500.0
-#define GROUND_CHECK_DELAY 8.0
 
 void RegBotGroundCheck() {
 	HookEvent("player_spawn", OnPlayerSpawn, EventHookMode_PostNoCopy);
@@ -21,7 +19,7 @@ public Action OnPlayerSpawn(Event event, const char[] name, bool dontBroadcast)
 		coords[client][1] = pos[1];
 		
 		// Wait 8 seconds before checking, so bots can capture resources (if required)
-		CreateTimer(GROUND_CHECK_DELAY, Timer_CheckBot, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE);
+		CreateTimer(gCheck_SpawnDelay.FloatValue, Timer_CheckBot, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE);
 	}
 	
 	return Plugin_Continue;
@@ -53,7 +51,7 @@ public Action Timer_CheckBot(Handle timer, any userid)
 		GetEntPropVector(bunker, Prop_Send, "m_vecOrigin", bunkerPos);			
 		
 		// Teleport bot out, if they're close to the bunker (base spawn)
-		if (GetVectorDistance(pos, bunkerPos) < fMaxBunkerDistance)
+		if (GetVectorDistance(pos, bunkerPos) < gCheck_BunkerDistance.FloatValue)
 			TeleportEntity(client, pos, NULL_VECTOR, NULL_VECTOR);
 	}
 	

--- a/addons/sourcemod/scripting/nd_pull_bot/move_bot.sp
+++ b/addons/sourcemod/scripting/nd_pull_bot/move_bot.sp
@@ -1,7 +1,3 @@
-#define fMaxDistance 300.0
-#define RETRY_DELAY 8
-#define INVALID_USERID 0
-
 bool CanPullBot[MAXPLAYERS+1] = { true , ... };
 
 void RegPullBotCommand() {
@@ -20,7 +16,8 @@ public Action Command_pull(client, args)
 		
 	if (!CanPullBot[client])
 	{
-		PrintToChat(client, "Please try again in %s seconds.", NumberInEnglish(RETRY_DELAY));
+		PrintToChat(client, "Please try again in %s seconds.", 
+				    NumberInEnglish(mBot_RetryDelay.IntValue));				     
 		return Plugin_Handled;
 	}
 
@@ -42,7 +39,7 @@ public Action Command_pull(client, args)
 		int target = TR_GetEntityIndex(hTrace);
 		if (target > 0 && IsFakeClient(target)) 
 		{
-			if(GetVectorDistance(vecOrigin, vecPos) < fMaxDistance) 
+			if(GetVectorDistance(vecOrigin, vecPos) < mBot_MaxDistance.FloatValue) 
 			{
 				TeleportEntity(target, vecOrigin, NULL_VECTOR, NULL_VECTOR);
 				PrintToChat(client, "bot moved");
@@ -56,7 +53,7 @@ public Action Command_pull(client, args)
 	
 	// Create cooldown before the client can pull a bot again
 	CanPullBot[client] = false;
-	CreateTimer(float(RETRY_DELAY), PullBotCooldown, GetClientUserId(client), TIMER_REPEAT | TIMER_FLAG_NO_MAPCHANGE);
+	CreateTimer(mBot_RetryDelay.FloatValue, PullBotCooldown, GetClientUserId(client), TIMER_REPEAT | TIMER_FLAG_NO_MAPCHANGE);
 	
 	return Plugin_Handled;
 }

--- a/addons/sourcemod/scripting/nd_pull_bot/move_bot.sp
+++ b/addons/sourcemod/scripting/nd_pull_bot/move_bot.sp
@@ -38,14 +38,19 @@ public Action Command_pull(client, args)
 		int target = TR_GetEntityIndex(hTrace);
 		if (target > 0 && IsFakeClient(target)) 
 		{
-			if(GetVectorDistance(vecOrigin, vecPos) < mBot_MaxDistance.FloatValue) 
+			float botDistance = GetVectorDistance(vecOrigin, vecPos);
+			float maxDistance = mBot_MaxDistance.FloatValue;
+			if(botDistance < maxDistance) 
 			{
 				TeleportEntity(target, vecOrigin, NULL_VECTOR, NULL_VECTOR);
 				PrintMessage(client, "Bot Pull Successful");
 			}
 			
 			else
-				PrintMessage(client, "Bot Too Far");
+			{
+				int units = botDistance - maxDistance; 
+				PrintMessageTI1(client, "Bot Too Far", units);
+			}
 		}
 		else
 			PrintMessage(client, "Bot Not Found");

--- a/addons/sourcemod/scripting/nd_pull_bot/move_bot.sp
+++ b/addons/sourcemod/scripting/nd_pull_bot/move_bot.sp
@@ -16,6 +16,7 @@ public Action Command_pull(client, args)
 		
 	if (!CanPullBot[client])
 	{
+		// To Do: Move this phrase "Please wait %d seconds for this feature" to nd_common.phrases
 		PrintMessageTI1(client, "Pull Retry Delay", mBot_RetryDelay.IntValue);			     
 		return Plugin_Handled;
 	}

--- a/addons/sourcemod/scripting/nd_pull_bot/move_bot.sp
+++ b/addons/sourcemod/scripting/nd_pull_bot/move_bot.sp
@@ -16,8 +16,7 @@ public Action Command_pull(client, args)
 		
 	if (!CanPullBot[client])
 	{
-		PrintToChat(client, "Please try again in %s seconds.", 
-				    NumberInEnglish(mBot_RetryDelay.IntValue));				     
+		PrintMessageTI1(client, "Pull Retry Delay", mBot_RetryDelay.IntValue);			     
 		return Plugin_Handled;
 	}
 
@@ -42,12 +41,14 @@ public Action Command_pull(client, args)
 			if(GetVectorDistance(vecOrigin, vecPos) < mBot_MaxDistance.FloatValue) 
 			{
 				TeleportEntity(target, vecOrigin, NULL_VECTOR, NULL_VECTOR);
-				PrintToChat(client, "bot moved");
+				PrintMessage(client, "Bot Pull Successful");
 			}
 			
 			else
-				PrintToChat(client, "bot too far");
+				PrintMessage(client, "Bot Too Far");
 		}
+		else
+			PrintMessage(client, "Bot Not Found");
 	}	
 	CloseHandle(hTrace);
 	

--- a/updater/nd_pull_bot/translations/nd_pull_bot.phrases.txt
+++ b/updater/nd_pull_bot/translations/nd_pull_bot.phrases.txt
@@ -1,0 +1,24 @@
+"Phrases"
+{
+	"Pull Retry Delay"
+	{
+		"#format"	"{1:i}"
+		"en"		"Please wait {1} seconds for this feature"	
+	}
+	
+	"Bot Too Far"
+	{
+		"#format"	"{1:i}"
+		"en"		"Bot is {1} units too far away to pull"	
+	}
+	
+	"Bot Pull Successful"
+	{
+		"en"		"Bot successfully pulled toward you"
+	}
+	
+	"Bot Not Found"
+	{
+		"en"		"No bot was found in your crosshair"	
+	}
+}


### PR DESCRIPTION
- Add 8 second cooldown for using !PullBot

- Default ground_check to disabled if stype becomes unavailable.

- Increase ground check delay from 3s to 8s, so bots can capture resources.

- Use convars to control distance & delay variables. (instead of hard-coding)

- Add translation support to bot pull messages.

- Display a message when no bot is found in the cross-hair

- Enhance message of bot being too far away, by displaying units.