### PR TITLE
Fix Structure Damage Exploit

### DIFF
--- a/addons/sourcemod/scripting/nd_damage/convars.sp
+++ b/addons/sourcemod/scripting/nd_damage/convars.sp
@@ -1,5 +1,5 @@
 /* The convar mess starts here! */
-#define CONFIG_VARS 20
+#define CONFIG_VARS 24
 enum
 {
     	nx300_bunker_mult = 0,
@@ -25,7 +25,13 @@ enum
 	bullet_radar_mult,
 	bullet_mg_turret_mult,
 	bullet_rocket_turret_mult,
-	bullet_supply_station_mult
+	bullet_supply_station_mult,
+	
+	// GLs (Grenade Launchers)
+	gl_bunker_mult,
+	gl_assembler_mult,
+	gl_transport_mult,
+	gl_ft_turret_mult
 }
 ConVar g_Cvar[CONFIG_VARS];
 float g_Float[CONFIG_VARS];
@@ -59,7 +65,13 @@ void CreatePluginConVars()
 		"sm_mult_radar_bullet",
 		"sm_mult_mg_turret_bullet",
 		"sm_mult_rocket_turret_bullet",
-		"sm_mult_supply_station_bullet"
+		"sm_mult_supply_station_bullet",
+		
+		// GLs (Grenade Launchers)
+		"sm_mult_bunker_gl",
+		"sm_mult_assembler_gl",
+		"sm_mult_transport_gl",
+		"sm_mult_ft_turret_gl"
 	};
 	
 	char convarDef[CONFIG_VARS][] = { 
@@ -67,7 +79,9 @@ void CreatePluginConVars()
 		// REDs (Remote Explosive Devices)
 		"120", "105", "150", "110", "140", "105", "105", "105",
 		// Bullets (Chainguns, Pistols, Rifles, SMGs etc)
-		"150", "140", "135", "95", "115", "125", "115", "100", "115", "100", "75"};
+		"150", "140", "135", "95", "115", "125", "115", "100", "115", "100", "75",
+		// GLs (Grenade Launchers)
+		"120", "110", "125", "115"};
 	
 	char convarDesc[CONFIG_VARS][] = {
 		"Percentage of normal damage nx300 does to bunker",
@@ -93,7 +107,13 @@ void CreatePluginConVars()
 		"Percentage of normal damage bullets deal to radars",
 		"Percentage of normal damage bullets deal to mg turrets",
 		"Percentage of normal damage bullets deal to rocket turrets",
-		"Percentage of normal damage bullets deal to supply stations"
+		"Percentage of normal damage bullets deal to supply stations",
+		
+		// GLs (Grenade Launchers)
+		"Percentage of normal damage GLs deal to the bunker",
+		"Percentage of normal damage GLs deal to assemblers",
+		"Percentage of normal damage GLs deal to transport gates",
+		"Percentage of normal damage REDs deal to ft/sonic turrets"		
 	};
 	
 	for (int convar = 0; convar < CONFIG_VARS; convar++) {

--- a/addons/sourcemod/scripting/nd_damage/damage_events.sp
+++ b/addons/sourcemod/scripting/nd_damage/damage_events.sp
@@ -3,6 +3,9 @@
 #define WEAPON_BULLET_DT 2
 #define BLOCK_DAMAGE 0
 
+#define WEAPON_GL_CNAME "grenade_launcher_proj"
+#define WEAPON_RED_CNAME "sticky_grenade_ent"
+
 public Action ND_OnSupplyStationDamaged(int victim, int &attacker, int &inflictor, float &damage, int &damagetype)
 {
 	if (IsValidEntity(inflictor) && damagetype == WEAPON_BULLET_DT)
@@ -44,8 +47,8 @@ public Action ND_OnRadarDamaged(int victim, int &attacker, int &inflictor, float
 	switch (damagetype)
 	{
 		case WEAPON_EXPLO_DT:
-		{
-			if (InflictorIsRED(inflictor))
+		{		
+			if (InflictorIsRED(iClass(inflictor)))
 			{			
 				damage *= g_Float[red_radar_mult];
 				return Plugin_Changed;
@@ -71,7 +74,7 @@ public Action ND_OnArmouryDamaged(int victim, int &attacker, int &inflictor, flo
 	{
 		case WEAPON_EXPLO_DT:
 		{
-			if (InflictorIsRED(inflictor))
+			if (InflictorIsRED(iClass(inflictor)))
 			{
 				damage *= g_Float[red_armoury_mult];
 				return Plugin_Changed;
@@ -97,7 +100,7 @@ public Action ND_OnPowerPlantDamaged(int victim, int &attacker, int &inflictor, 
 	{
 		case WEAPON_EXPLO_DT:
 		{
-			if (InflictorIsRED(inflictor))
+			if (InflictorIsRED(iClass(inflictor)))
 			{
 				damage *= g_Float[red_power_plant_mult];
 				return Plugin_Changed;
@@ -123,7 +126,7 @@ public Action ND_OnFlamerTurretDamaged(int victim, int &attacker, int &inflictor
 	{
 		case WEAPON_EXPLO_DT:
 		{
-			if (InflictorIsRED(inflictor))
+			if (InflictorIsRED(iClass(inflictor)))
 			{
 				damage *= g_Float[red_ft_turret_mult];
 				return Plugin_Changed;
@@ -149,7 +152,7 @@ public Action ND_OnArtilleryDamaged(int victim, int &attacker, int &inflictor, f
 	{
 		case WEAPON_EXPLO_DT:
 		{
-			if (InflictorIsRED(inflictor))
+			if (InflictorIsRED(iClass(inflictor)))
 			{
 				damage *= g_Float[red_artillery_mult];
 				return Plugin_Changed;
@@ -175,11 +178,16 @@ public Action ND_OnTransportDamaged(int victim, int &attacker, int &inflictor, f
 	{
 		case WEAPON_EXPLO_DT:
 		{
-			if (InflictorIsRED(inflictor))
+			char className[64];
+			GetEntityClassname(inflictor, className, sizeof(className));
+			
+			if (InflictorIsRED(className))
 			{
 				damage *= g_Float[red_transport_mult];
 				return Plugin_Changed;
 			}
+			else if (InflictorIsGL(className))
+				return Plugin_Continue;
 		}
 		
 		case WEAPON_BULLET_DT: 
@@ -201,11 +209,16 @@ public Action ND_OnAssemblerDamaged(int victim, int &attacker, int &inflictor, f
 	{
 		case WEAPON_EXPLO_DT:	 
 		{ 
-			if (InflictorIsRED(inflictor))
+			char className[64];
+			GetEntityClassname(inflictor, className, sizeof(className));
+			
+			if (InflictorIsRED(className))
 			{
 				damage *= g_Float[red_assembler_mult]; 
 				return Plugin_Changed;
 			}
+			else if (InflictorIsGL(className))
+				return Plugin_Continue;
 		}
 		
 		case WEAPON_BULLET_DT:
@@ -240,11 +253,16 @@ public Action ND_OnBunkerDamaged(int victim, int &attacker, int &inflictor, floa
 		
 		case WEAPON_EXPLO_DT:
 		{ 
-			if (InflictorIsRED(inflictor))
+			char className[64];
+			GetEntityClassname(inflictor, className, sizeof(className));
+			
+			if (InflictorIsRED(className))
 			{
 				damage *= g_Float[red_bunker_mult];
 				return Plugin_Changed;
-			}
+			}			
+			else if (InflictorIsGL(className))
+				return Plugin_Continue;
 		}
 		
 		case WEAPON_BULLET_DT:	
@@ -257,10 +275,17 @@ public Action ND_OnBunkerDamaged(int victim, int &attacker, int &inflictor, floa
 	return Plugin_Continue;
 }
 
-bool InflictorIsRED(int &inflictor)
+bool InflictorIsRED(const char[] className) {
+	return StrEqual(className, WEAPON_RED_CNAME, true);
+}
+
+bool InflictorIsGL(const char[] className) {
+	return StrEqual(className, WEAPON_GL_CNAME, true);
+}
+
+char iClass(const char[] className)
 {
 	char className[64];
-	GetEntityClassname(inflictor, className, sizeof(className)); 
-			
-	return (StrEqual(className, "sticky_grenade_ent", true));
+	GetEntityClassname(inflictor, className, sizeof(className));
+	return className;			
 }

--- a/addons/sourcemod/scripting/nd_damage/damage_events.sp
+++ b/addons/sourcemod/scripting/nd_damage/damage_events.sp
@@ -126,7 +126,10 @@ public Action ND_OnFlamerTurretDamaged(int victim, int &attacker, int &inflictor
 	{
 		case WEAPON_EXPLO_DT:
 		{
-			if (InflictorIsRED(iClass(inflictor)))
+			char className[64];
+			GetEntityClassname(inflictor, className, sizeof(className));
+			
+			if (InflictorIsRED(className))
 			{
 				damage *= g_Float[red_ft_turret_mult];
 				return Plugin_Changed;

--- a/addons/sourcemod/scripting/nd_damage/damage_events.sp
+++ b/addons/sourcemod/scripting/nd_damage/damage_events.sp
@@ -283,7 +283,7 @@ bool InflictorIsGL(const char[] className) {
 	return StrEqual(className, WEAPON_GL_CNAME, true);
 }
 
-char iClass(const char[] className)
+char iClass(int &inflictor)
 {
 	char className[64];
 	GetEntityClassname(inflictor, className, sizeof(className));

--- a/addons/sourcemod/scripting/nd_damage/damage_events.sp
+++ b/addons/sourcemod/scripting/nd_damage/damage_events.sp
@@ -1,5 +1,5 @@
 #define WEAPON_NX300_DT -2147481592
-#define WEAPON_RED_DT 64
+#define WEAPON_EXPLO_DT 64
 #define WEAPON_BULLET_DT 2
 #define BLOCK_DAMAGE 0
 
@@ -43,10 +43,13 @@ public Action ND_OnRadarDamaged(int victim, int &attacker, int &inflictor, float
 	
 	switch (damagetype)
 	{
-		case WEAPON_RED_DT:
+		case WEAPON_EXPLO_DT:
 		{
-			damage *= g_Float[red_radar_mult];
-			return Plugin_Changed;
+			if (InflictorIsRED(inflictor))
+			{			
+				damage *= g_Float[red_radar_mult];
+				return Plugin_Changed;
+			}
 		}
 		
 		case WEAPON_BULLET_DT:
@@ -66,10 +69,13 @@ public Action ND_OnArmouryDamaged(int victim, int &attacker, int &inflictor, flo
 	
 	switch (damagetype)
 	{
-		case WEAPON_RED_DT:
+		case WEAPON_EXPLO_DT:
 		{
-			damage *= g_Float[red_armoury_mult];
-			return Plugin_Changed;			
+			if (InflictorIsRED(inflictor))
+			{
+				damage *= g_Float[red_armoury_mult];
+				return Plugin_Changed;
+			}
 		}
 		
 		case WEAPON_BULLET_DT:
@@ -89,10 +95,13 @@ public Action ND_OnPowerPlantDamaged(int victim, int &attacker, int &inflictor, 
 	
 	switch(damagetype)
 	{
-		case WEAPON_RED_DT:
+		case WEAPON_EXPLO_DT:
 		{
-			damage *= g_Float[red_power_plant_mult];
-			return Plugin_Changed;			
+			if (InflictorIsRED(inflictor))
+			{
+				damage *= g_Float[red_power_plant_mult];
+				return Plugin_Changed;
+			}
 		}
 		
 		case WEAPON_BULLET_DT:
@@ -112,10 +121,13 @@ public Action ND_OnFlamerTurretDamaged(int victim, int &attacker, int &inflictor
 	
 	switch (damagetype)
 	{
-		case WEAPON_RED_DT:
+		case WEAPON_EXPLO_DT:
 		{
-			damage *= g_Float[red_ft_turret_mult];
-			return Plugin_Changed;			
+			if (InflictorIsRED(inflictor))
+			{
+				damage *= g_Float[red_ft_turret_mult];
+				return Plugin_Changed;
+			}
 		}
 		
 		case WEAPON_BULLET_DT:
@@ -135,10 +147,13 @@ public Action ND_OnArtilleryDamaged(int victim, int &attacker, int &inflictor, f
 	
 	switch (damagetype)
 	{
-		case WEAPON_RED_DT:
+		case WEAPON_EXPLO_DT:
 		{
-			damage *= g_Float[red_artillery_mult];
-			return Plugin_Changed;
+			if (InflictorIsRED(inflictor))
+			{
+				damage *= g_Float[red_artillery_mult];
+				return Plugin_Changed;
+			}
 		}
 		
 		case WEAPON_BULLET_DT: 
@@ -158,10 +173,13 @@ public Action ND_OnTransportDamaged(int victim, int &attacker, int &inflictor, f
 	
 	switch (damagetype)
 	{
-		case WEAPON_RED_DT:
+		case WEAPON_EXPLO_DT:
 		{
-			damage *= g_Float[red_transport_mult];
-			return Plugin_Changed;
+			if (InflictorIsRED(inflictor))
+			{
+				damage *= g_Float[red_transport_mult];
+				return Plugin_Changed;
+			}
 		}
 		
 		case WEAPON_BULLET_DT: 
@@ -181,10 +199,13 @@ public Action ND_OnAssemblerDamaged(int victim, int &attacker, int &inflictor, f
 	
 	switch (damagetype)
 	{
-		case WEAPON_RED_DT:	 
+		case WEAPON_EXPLO_DT:	 
 		{ 
-			damage *= g_Float[red_assembler_mult]; 
-			return Plugin_Changed;
+			if (InflictorIsRED(inflictor))
+			{
+				damage *= g_Float[red_assembler_mult]; 
+				return Plugin_Changed;
+			}
 		}
 		
 		case WEAPON_BULLET_DT:
@@ -217,10 +238,13 @@ public Action ND_OnBunkerDamaged(int victim, int &attacker, int &inflictor, floa
 			return Plugin_Changed; 
 		}
 		
-		case WEAPON_RED_DT:
+		case WEAPON_EXPLO_DT:
 		{ 
-			damage *= g_Float[red_bunker_mult]; 		
-			return Plugin_Changed; 
+			if (InflictorIsRED(inflictor))
+			{
+				damage *= g_Float[red_bunker_mult];
+				return Plugin_Changed;
+			}
 		}
 		
 		case WEAPON_BULLET_DT:	
@@ -231,4 +255,12 @@ public Action ND_OnBunkerDamaged(int victim, int &attacker, int &inflictor, floa
 	}
 	
 	return Plugin_Continue;
+}
+
+bool InflictorIsRED(int &inflictor)
+{
+	char className[64];
+	GetEntityClassname(inflictor, className, sizeof(className)); 
+			
+	return (StrEqual(className, "sticky_grenade_ent", true));
 }

--- a/addons/sourcemod/scripting/nd_damage/damage_events.sp
+++ b/addons/sourcemod/scripting/nd_damage/damage_events.sp
@@ -131,6 +131,11 @@ public Action ND_OnFlamerTurretDamaged(int victim, int &attacker, int &inflictor
 				damage *= g_Float[red_ft_turret_mult];
 				return Plugin_Changed;
 			}
+			else if (InflictorIsGL(className))
+			{
+				damage *= g_Float[gl_ft_turret_mult];
+				return Plugin_Changed;
+			}
 		}
 		
 		case WEAPON_BULLET_DT:
@@ -187,7 +192,10 @@ public Action ND_OnTransportDamaged(int victim, int &attacker, int &inflictor, f
 				return Plugin_Changed;
 			}
 			else if (InflictorIsGL(className))
-				return Plugin_Continue;
+			{
+				damage *= g_Float[gl_transport_mult];
+				return Plugin_Changed;
+			}
 		}
 		
 		case WEAPON_BULLET_DT: 
@@ -218,7 +226,10 @@ public Action ND_OnAssemblerDamaged(int victim, int &attacker, int &inflictor, f
 				return Plugin_Changed;
 			}
 			else if (InflictorIsGL(className))
-				return Plugin_Continue;
+			{				
+				damage *= g_Float[gl_assembler_mult]; 
+				return Plugin_Changed;
+			}
 		}
 		
 		case WEAPON_BULLET_DT:
@@ -262,7 +273,10 @@ public Action ND_OnBunkerDamaged(int victim, int &attacker, int &inflictor, floa
 				return Plugin_Changed;
 			}			
 			else if (InflictorIsGL(className))
-				return Plugin_Continue;
+			{
+				damage *= g_Float[gl_bunker_mult];
+				return Plugin_Changed;
+			}
 		}
 		
 		case WEAPON_BULLET_DT:	

--- a/addons/sourcemod/scripting/nd_damage_mult.sp
+++ b/addons/sourcemod/scripting/nd_damage_mult.sp
@@ -3,6 +3,7 @@
 #include <sdkhooks>
 #include <nd_rounds>
 #include <nd_struct_eng>
+#include <nd_research_eng>
 
 public Plugin myinfo = 
 {


### PR DESCRIPTION
- Patch an exploit causing siege weapons and grenade launchers to deal RED intended damage.
This will result in weapons dealing the intended damage to structures, which is up to 40% less.

- Increase GL structure damage to bunker by 20%, assembler by 10%, ft/sonic turrets 15%, spawns 20%.
These values are exactly half the exploit levels, that were previously being implemented. 
They include removal of buildings that are too weak: armory, radar, artillery, power plant.