### PR TITLE
Rework damage ConVars with cleaner configurations

### DIFF
--- a/addons/sourcemod/scripting/nd_damage/convars.sp
+++ b/addons/sourcemod/scripting/nd_damage/convars.sp
@@ -137,7 +137,7 @@ void CreateOtherConVars()
 	AutoExecConfig_SetFile("nd_mult_other");
 	
 	char convarName[multOther][] = {	
-		sm_mult_bunker_nx300",
+		"sm_mult_bunker_nx300",
 		
 		// GLs (Grenade Launchers)
 		"sm_mult_bunker_gl",
@@ -146,7 +146,7 @@ void CreateOtherConVars()
 		"sm_mult_ft_turret_gl"
 	};
 	
-	char convarDef[multOther][] = { "120", "110", "125", "115" };
+	char convarDef[multOther][] = { "85", "120", "110", "125", "115" };
 	
 	char convarDesc[multOther][] = {
 		"Percentage of normal damage nx300 does to bunker",
@@ -180,11 +180,11 @@ void UpdateConVarCache()
 	}
 	
 	for (int b = 0; b < view_as<int>(multBullets); b++) {
-		g_Float_Bullet[b] = gCvar_Bullets[b].FloatValue / 100.0;
+		gFloat_Bullet[b] = gCvar_Bullets[b].FloatValue / 100.0;
 	}
 	
 	for (int o = 0; o < view_as<int>(multOther); o++) {
-		g_Float_Other[o] = g_Cvar_Other[o].FloatValue / 100.0;
+		gFloat_Other[o] = g_Cvar_Other[o].FloatValue / 100.0;
 	}
 }
 void HookConVarChanges()

--- a/addons/sourcemod/scripting/nd_damage/convars.sp
+++ b/addons/sourcemod/scripting/nd_damage/convars.sp
@@ -1,20 +1,20 @@
+#include <autoexecconfig>
 /* The convar mess starts here! */
-#define CONFIG_VARS 24
-enum
+
+/* Enumerated values for accessing ConVar arrays */
+enum multREDs 
 {
-    	nx300_bunker_mult = 0,
-		
-	// REDs (Remote Explosive Devices)
-    	red_bunker_mult,
+	red_bunker_mult,
 	red_assembler_mult,
 	red_transport_mult,
 	red_artillery_mult,
 	red_ft_turret_mult,
 	red_power_plant_mult,
 	red_armoury_mult,
-	red_radar_mult,
-		
-	// Bullets (Chainguns, Pistols, Rifles, SMGs etc)
+	red_radar_mult
+}
+enum multBullets
+{
 	bullet_bunker_mult,
 	bullet_assembler_mult,
 	bullet_transport_mult,
@@ -25,7 +25,11 @@ enum
 	bullet_radar_mult,
 	bullet_mg_turret_mult,
 	bullet_rocket_turret_mult,
-	bullet_supply_station_mult,
+	bullet_supply_station_mult
+}
+enum multOther
+{
+	nx300_bunker_mult = 0,
 	
 	// GLs (Grenade Launchers)
 	gl_bunker_mult,
@@ -33,18 +37,32 @@ enum
 	gl_transport_mult,
 	gl_ft_turret_mult
 }
-ConVar g_Cvar[CONFIG_VARS];
-float g_Float[CONFIG_VARS];
 
+/* ConVar and float arrays for the different types */
+ConVar gCvar_Red[multREDs];
+ConVar gCvar_Bullets[multBullets];
+ConVar gCvar_Other[multOther];
 ConVar cvarNoWarmupBunkerDamage;
 
-/* The convar mess for controlling plugin settings on the fly */
+float gFloat_Red[multREDs];
+float gFloat_Bullet[multBullets];
+float gFloat_Other[multOther];
+
+/* Functions for creating covnars */
 void CreatePluginConVars()
 {
-	char convarName[CONFIG_VARS][] = {
-		"sm_mult_bunker_nx300",
-		
-		// REDs (Remote Denotinated Explosives)
+	CreateRedConVars();
+	CreateBulletConVars();
+	CreateOtherConVars();
+	
+	cvarNoWarmupBunkerDamage = CreateConVar("sm_warmup_protect_bunker", "1", "Disable bunker damage during the warmup round.");
+}
+
+void CreateRedConVars()
+{
+	AutoExecConfig_SetFile("nd_mult_reds");
+	
+	char convarName[multREDs][] = {
 		"sm_mult_bunker_red",
 		"sm_mult_assembler_red",
 		"sm_mult_transport_red",
@@ -52,9 +70,33 @@ void CreatePluginConVars()
 		"sm_mult_ft_turret_red",
 		"sm_mult_power_plant_red",
 		"sm_mult_armoury_red",
-		"sm_mult_radar_red",
-		
-		// Bullets (Chainguns, Pistols, Rifles, SMGs etc)
+		"sm_mult_radar_red"		
+	};
+	
+	char convarDef[multREDs][] = { "120", "105", "150", "110", "140", "105", "105", "105"};
+	
+	char convarDesc[multREDs][] = {
+		"Percentage of normal damage REDs deal to the bunker",
+		"Percentage of normal damage REDs deal to assemblers",
+		"Percentage of normal damage REDs deal to transport gates",
+		"Percentage of normal damage REDs deal to artillery",
+		"Percentage of normal damage REDs deal to ft/sonic turrets",
+		"Percentage of normal damage REDs deal to power plants",
+		"Percentage of normal damage REDs deal to armouries",
+		"Percentage of normal damage REDs deal to radars"
+	};	
+	
+	for (int convar = 0; convar < view_as<int>(multREDs); convar++) {
+		gCvar_Red[convar] = AutoExecConfig_CreateConVar(convarName[convar], convarDef[convar], convarDesc[convar]);	
+	}
+	
+	AutoExecConfig_EC_File();
+}
+void CreateBulletConVars()
+{
+	AutoExecConfig_SetFile("nd_mult_bullet");
+	
+	char convarName[multBullets][] = {	
 		"sm_mult_bunker_bullet",
 		"sm_mult_assembler_bullet",
 		"sm_mult_transport_bullet",
@@ -65,38 +107,12 @@ void CreatePluginConVars()
 		"sm_mult_radar_bullet",
 		"sm_mult_mg_turret_bullet",
 		"sm_mult_rocket_turret_bullet",
-		"sm_mult_supply_station_bullet",
-		
-		// GLs (Grenade Launchers)
-		"sm_mult_bunker_gl",
-		"sm_mult_assembler_gl",
-		"sm_mult_transport_gl",
-		"sm_mult_ft_turret_gl"
+		"sm_mult_supply_station_bullet"
 	};
 	
-	char convarDef[CONFIG_VARS][] = { 
-		"85", // NX300 (Flamethrower)
-		// REDs (Remote Explosive Devices)
-		"120", "105", "150", "110", "140", "105", "105", "105",
-		// Bullets (Chainguns, Pistols, Rifles, SMGs etc)
-		"150", "140", "135", "95", "115", "125", "115", "100", "115", "100", "75",
-		// GLs (Grenade Launchers)
-		"120", "110", "125", "115"};
+	char convarDef[multBullets][] = { "150", "140", "135", "95", "115", "125", "115", "100", "115", "100", "75" };
 	
-	char convarDesc[CONFIG_VARS][] = {
-		"Percentage of normal damage nx300 does to bunker",
-		
-		// REDs (Remote Explosive Devices)
-		"Percentage of normal damage REDs deal to the bunker",
-		"Percentage of normal damage REDs deal to assemblers",
-		"Percentage of normal damage REDs deal to transport gates",
-		"Percentage of normal damage REDs deal to artillery",
-		"Percentage of normal damage REDs deal to ft/sonic turrets",
-		"Percentage of normal damage REDs deal to power plants",
-		"Percentage of normal damage REDs deal to armouries",
-		"Percentage of normal damage REDs deal to radars",
-		
-		// Bullets (Chainguns, Pistols, Rifles, SMGs etc)
+	char convarDesc[multBullets][] = {
 		"Percentage of normal damage bullets deal to the bunker",
 		"Percentage of normal damage bullets deal to assemblers",
 		"Percentage of normal damage bullets deal to transport gates",
@@ -107,36 +123,84 @@ void CreatePluginConVars()
 		"Percentage of normal damage bullets deal to radars",
 		"Percentage of normal damage bullets deal to mg turrets",
 		"Percentage of normal damage bullets deal to rocket turrets",
-		"Percentage of normal damage bullets deal to supply stations",
+		"Percentage of normal damage bullets deal to supply stations"
+	};
+	
+	for (int convar = 0; convar < view_as<int>(multBullets); convar++) {
+		gCvar_Bullet[convar] = AutoExecConfig_CreateConVar(convarName[convar], convarDef[convar], convarDesc[convar]);	
+	}
+	
+	AutoExecConfig_EC_File();	
+}
+void CreateOtherConVars()
+{
+	AutoExecConfig_SetFile("nd_mult_other");
+	
+	char convarName[multOther][] = {	
+		sm_mult_bunker_nx300",
+		
+		// GLs (Grenade Launchers)
+		"sm_mult_bunker_gl",
+		"sm_mult_assembler_gl",
+		"sm_mult_transport_gl",
+		"sm_mult_ft_turret_gl"
+	};
+	
+	char convarDef[multOther][] = { "120", "110", "125", "115" };
+	
+	char convarDesc[multOther][] = {
+		"Percentage of normal damage nx300 does to bunker",
 		
 		// GLs (Grenade Launchers)
 		"Percentage of normal damage GLs deal to the bunker",
 		"Percentage of normal damage GLs deal to assemblers",
 		"Percentage of normal damage GLs deal to transport gates",
-		"Percentage of normal damage GLs deal to ft/sonic turrets"		
+		"Percentage of normal damage GLs deal to ft/sonic turrets"
 	};
 	
-	for (int convar = 0; convar < CONFIG_VARS; convar++) {
-		g_Cvar[convar] = CreateConVar(convarName[convar], convarDef[convar], convarDesc[convar]);	
+	for (int convar = 0; convar < view_as<int>(multOther); convar++) {
+		gCvar_Other[convar] = AutoExecConfig_CreateConVar(convarName[convar], convarDef[convar], convarDesc[convar]);	
 	}
 	
-	cvarNoWarmupBunkerDamage = CreateConVar("sm_warmup_protect_bunker", "1", "Disable bunker damage during the warmup round.");
+	AutoExecConfig_EC_File();	
 }
 
+void AutoExecConfig_EC_File()
+{
+	// Execute and clean the cfg file
+	AutoExecConfig_ExecuteFile();	
+	AutoExecConfig_CleanFile();
+}
+
+/* Manage when ConVars change mid-game */
 void UpdateConVarCache()
 {
-	for (int i = 0; i < CONFIG_VARS; i++)	{
-		g_Float[i] = g_Cvar[i].FloatValue / 100.0;	
+	for (int r = 0; r < view_as<int>(multREDs); r++) {
+		gFloat_Red[r] = gCvar_Red[r].FloatValue / 100.0;
+	}
+	
+	for (int b = 0; b < view_as<int>(multBullets); b++) {
+		g_Float_Bullet[b] = gCvar_Bullets[b].FloatValue / 100.0;
+	}
+	
+	for (int o = 0; o < view_as<int>(multOther); o++) {
+		g_Float_Other[o] = g_Cvar_Other[o].FloatValue / 100.0;
 	}
 }
-
 void HookConVarChanges()
 {
-	for (int i = 0; i < CONFIG_VARS; i++)	{
-		HookConVarChange(g_Cvar[i], OnConfigPercentChange);
+	for (int r = 0; r < view_as<int>(multREDs); r++) {
+		HookConVarChange(gCvar_Red[r], OnConfigPercentChange);
+	}
+	
+	for (int b = 0; b < view_as<int>(multBullets); b++) {
+		HookConVarChange(gCvar_Bullets[b], OnConfigPercentChange);
+	}
+	
+	for (int o = 0; o < view_as<int>(multOther); o++) {
+		HookConVarChange(g_Cvar_Other[o], OnConfigPercentChange);
 	}
 }
-
 public void OnConfigPercentChange(ConVar convar, char[] oldValue, char[] newValue) {	
 	UpdateConVarCache();
 }

--- a/addons/sourcemod/scripting/nd_damage/convars.sp
+++ b/addons/sourcemod/scripting/nd_damage/convars.sp
@@ -198,7 +198,7 @@ void HookConVarChanges()
 	}
 	
 	for (int o = 0; o < view_as<int>(multOther); o++) {
-		HookConVarChange(g_Cvar_Other[o], OnConfigPercentChange);
+		HookConVarChange(gCvar_Other[o], OnConfigPercentChange);
 	}
 }
 public void OnConfigPercentChange(ConVar convar, char[] oldValue, char[] newValue) {	

--- a/addons/sourcemod/scripting/nd_damage/convars.sp
+++ b/addons/sourcemod/scripting/nd_damage/convars.sp
@@ -184,7 +184,7 @@ void UpdateConVarCache()
 	}
 	
 	for (int o = 0; o < view_as<int>(multOther); o++) {
-		gFloat_Other[o] = g_Cvar_Other[o].FloatValue / 100.0;
+		gFloat_Other[o] = gCvar_Other[o].FloatValue / 100.0;
 	}
 }
 void HookConVarChanges()

--- a/addons/sourcemod/scripting/nd_damage/convars.sp
+++ b/addons/sourcemod/scripting/nd_damage/convars.sp
@@ -180,7 +180,7 @@ void UpdateConVarCache()
 	}
 	
 	for (int b = 0; b < view_as<int>(multBullets); b++) {
-		gFloat_Bullet[b] = gCvar_Bullets[b].FloatValue / 100.0;
+		gFloat_Bullet[b] = gCvar_Bullet[b].FloatValue / 100.0;
 	}
 	
 	for (int o = 0; o < view_as<int>(multOther); o++) {
@@ -194,7 +194,7 @@ void HookConVarChanges()
 	}
 	
 	for (int b = 0; b < view_as<int>(multBullets); b++) {
-		HookConVarChange(gCvar_Bullets[b], OnConfigPercentChange);
+		HookConVarChange(gCvar_Bullet[b], OnConfigPercentChange);
 	}
 	
 	for (int o = 0; o < view_as<int>(multOther); o++) {

--- a/addons/sourcemod/scripting/nd_damage/convars.sp
+++ b/addons/sourcemod/scripting/nd_damage/convars.sp
@@ -40,7 +40,7 @@ enum multOther
 
 /* ConVar and float arrays for the different types */
 ConVar gCvar_Red[multREDs];
-ConVar gCvar_Bullets[multBullets];
+ConVar gCvar_Bullet[multBullets];
 ConVar gCvar_Other[multOther];
 ConVar cvarNoWarmupBunkerDamage;
 

--- a/addons/sourcemod/scripting/nd_damage/damage_events.sp
+++ b/addons/sourcemod/scripting/nd_damage/damage_events.sp
@@ -10,7 +10,7 @@ public Action ND_OnSupplyStationDamaged(int victim, int &attacker, int &inflicto
 {
 	if (IsValidEntity(inflictor) && damagetype == WEAPON_BULLET_DT)
 	{
-		damage *= g_Float[bullet_supply_station_mult];
+		damage *= gFloat_Bullet[bullet_supply_station_mult];
 		return Plugin_Changed;
 	}
 	
@@ -21,7 +21,7 @@ public Action ND_OnRocketTurretDamaged(int victim, int &attacker, int &inflictor
 {
 	if (IsValidEntity(inflictor) && damagetype == WEAPON_BULLET_DT)
 	{
-		damage *= g_Float[bullet_rocket_turret_mult];
+		damage *= gFloat_Bullet[bullet_rocket_turret_mult];
 		return Plugin_Changed;
 	}
 	
@@ -32,7 +32,7 @@ public Action ND_OnMGTurretDamaged(int victim, int &attacker, int &inflictor, fl
 {
 	if (IsValidEntity(inflictor) && damagetype == WEAPON_BULLET_DT)
 	{
-		damage *= g_Float[bullet_mg_turret_mult];
+		damage *= gFloat_Bullet[bullet_mg_turret_mult];
 		return Plugin_Changed;
 	}
 	
@@ -50,14 +50,14 @@ public Action ND_OnRadarDamaged(int victim, int &attacker, int &inflictor, float
 		{		
 			if (InflictorIsRED(iClass(inflictor)))
 			{			
-				damage *= g_Float[red_radar_mult];
+				damage *= gFloat_Red[red_radar_mult];
 				return Plugin_Changed;
 			}
 		}
 		
 		case WEAPON_BULLET_DT:
 		{
-			damage *= g_Float[bullet_radar_mult];
+			damage *= gFloat_Bullet[bullet_radar_mult];
 			return Plugin_Changed;			
 		}		
 	}
@@ -76,14 +76,14 @@ public Action ND_OnArmouryDamaged(int victim, int &attacker, int &inflictor, flo
 		{
 			if (InflictorIsRED(iClass(inflictor)))
 			{
-				damage *= g_Float[red_armoury_mult];
+				damage *= gFloat_Red[red_armoury_mult];
 				return Plugin_Changed;
 			}
 		}
 		
 		case WEAPON_BULLET_DT:
 		{
-			damage *= g_Float[bullet_armoury_mult];
+			damage *= gFloat_Bullet[bullet_armoury_mult];
 			return Plugin_Changed;			
 		}		
 	}
@@ -102,14 +102,14 @@ public Action ND_OnPowerPlantDamaged(int victim, int &attacker, int &inflictor, 
 		{
 			if (InflictorIsRED(iClass(inflictor)))
 			{
-				damage *= g_Float[red_power_plant_mult];
+				damage *= gFloat_Red[red_power_plant_mult];
 				return Plugin_Changed;
 			}
 		}
 		
 		case WEAPON_BULLET_DT:
 		{
-			damage *= g_Float[bullet_power_plant_mult];
+			damage *= gFloat_Bullet[bullet_power_plant_mult];
 			return Plugin_Changed;			
 		}		
 	}
@@ -131,19 +131,19 @@ public Action ND_OnFlamerTurretDamaged(int victim, int &attacker, int &inflictor
 			
 			if (InflictorIsRED(className))
 			{
-				damage *= g_Float[red_ft_turret_mult];
+				damage *= gFloat_Red[red_ft_turret_mult];
 				return Plugin_Changed;
 			}
 			else if (InflictorIsGL(className))
 			{
-				damage *= g_Float[gl_ft_turret_mult];
+				damage *= gFloat_Other[gl_ft_turret_mult];
 				return Plugin_Changed;
 			}
 		}
 		
 		case WEAPON_BULLET_DT:
 		{
-			damage *= g_Float[bullet_ft_turret_mult];
+			damage *= gFloat_Bullet[bullet_ft_turret_mult];
 			return Plugin_Changed;			
 		}		
 	}
@@ -162,14 +162,14 @@ public Action ND_OnArtilleryDamaged(int victim, int &attacker, int &inflictor, f
 		{
 			if (InflictorIsRED(iClass(inflictor)))
 			{
-				damage *= g_Float[red_artillery_mult];
+				damage *= gFloat_Red[red_artillery_mult];
 				return Plugin_Changed;
 			}
 		}
 		
 		case WEAPON_BULLET_DT: 
 		{
-			damage *= g_Float[bullet_artillery_mult];
+			damage *= gFloat_Bullet[bullet_artillery_mult];
 			return Plugin_Changed;			
 		}		
 	}
@@ -191,19 +191,19 @@ public Action ND_OnTransportDamaged(int victim, int &attacker, int &inflictor, f
 			
 			if (InflictorIsRED(className))
 			{
-				damage *= g_Float[red_transport_mult];
+				damage *= gFloat_Red[red_transport_mult];
 				return Plugin_Changed;
 			}
 			else if (InflictorIsGL(className))
 			{
-				damage *= g_Float[gl_transport_mult];
+				damage *= gFloat_Other[gl_transport_mult];
 				return Plugin_Changed;
 			}
 		}
 		
 		case WEAPON_BULLET_DT: 
 		{
-			damage *= g_Float[bullet_transport_mult];
+			damage *= gFloat_Bullet[bullet_transport_mult];
 			return Plugin_Changed;
 		}		
 	}
@@ -225,19 +225,19 @@ public Action ND_OnAssemblerDamaged(int victim, int &attacker, int &inflictor, f
 			
 			if (InflictorIsRED(className))
 			{
-				damage *= g_Float[red_assembler_mult]; 
+				damage *= gFloat_Red[red_assembler_mult]; 
 				return Plugin_Changed;
 			}
 			else if (InflictorIsGL(className))
 			{				
-				damage *= g_Float[gl_assembler_mult]; 
+				damage *= gFloat_Other[gl_assembler_mult]; 
 				return Plugin_Changed;
 			}
 		}
 		
 		case WEAPON_BULLET_DT:
 		{
-			damage *= g_Float[bullet_assembler_mult]; 
+			damage *= gFloat_Bullet[bullet_assembler_mult]; 
 			return Plugin_Changed;
 		}		
 	}
@@ -261,7 +261,7 @@ public Action ND_OnBunkerDamaged(int victim, int &attacker, int &inflictor, floa
 	{
 		case WEAPON_NX300_DT:
 		{ 
-			damage *= g_Float[nx300_bunker_mult]; 	
+			damage *= gFloat_Other[nx300_bunker_mult]; 	
 			return Plugin_Changed; 
 		}
 		
@@ -272,19 +272,19 @@ public Action ND_OnBunkerDamaged(int victim, int &attacker, int &inflictor, floa
 			
 			if (InflictorIsRED(className))
 			{
-				damage *= g_Float[red_bunker_mult];
+				damage *= gFloat_Red[red_bunker_mult];
 				return Plugin_Changed;
 			}			
 			else if (InflictorIsGL(className))
 			{
-				damage *= g_Float[gl_bunker_mult];
+				damage *= gFloat_Other[gl_bunker_mult];
 				return Plugin_Changed;
 			}
 		}
 		
 		case WEAPON_BULLET_DT:	
 		{ 
-			damage *= g_Float[bullet_bunker_mult];	
+			damage *= gFloat_Bullet[bullet_bunker_mult];	
 			return Plugin_Changed;
 		}
 	}


### PR DESCRIPTION
- Separate into three different config files by value to reduce scrolling.

- Automatically clean the configuration files to remove housekeeping.