### PR TITLE
Fix typo causing wrong bot pull delay

### DIFF
--- a/addons/sourcemod/scripting/include/autoexecconfig.inc
+++ b/addons/sourcemod/scripting/include/autoexecconfig.inc
@@ -80,7 +80,13 @@ static int g_bCreateDirectoryMode = FPERM_U_READ|FPERM_U_WRITE|FPERM_U_EXEC|FPER
 static int g_iLastFindResult;
 static int g_iLastAppendResult;
 
-
+// Custom wrapper for Redstone GitHub
+stock void AutoExecConfig_EC_File()
+{
+	// Execute and clean the cfg file
+	AutoExecConfig_ExecuteFile();	
+	AutoExecConfig_CleanFile();
+}
 
 
 /**

--- a/addons/sourcemod/scripting/nd_damage/convars.sp
+++ b/addons/sourcemod/scripting/nd_damage/convars.sp
@@ -195,13 +195,6 @@ void CreateOtherConVars()
 	AutoExecConfig_EC_File();	
 }
 
-void AutoExecConfig_EC_File()
-{
-	// Execute and clean the cfg file
-	AutoExecConfig_ExecuteFile();	
-	AutoExecConfig_CleanFile();
-}
-
 /* Manage when ConVars change mid-game */
 void UpdateConVarCache()
 {

--- a/addons/sourcemod/scripting/nd_pull_bot.sp
+++ b/addons/sourcemod/scripting/nd_pull_bot.sp
@@ -5,6 +5,8 @@
 #include <nd_stype>
 #include <nd_print>
 
+#include <autoexecconfig>
+
 #define INVALID_USERID 0
 
 public Plugin myinfo =
@@ -59,8 +61,20 @@ public void OnClientConnected(int client) {
 
 void CreatePluginConvars()
 {
-	gCheck_BunkerDistance	= CreateConVar("sm_gcheck_bdistance", "1500", "Distance away from bunker spawn must be to use feature");
-	gCheck_SpawnDelay 	= CreateConVar("sm_gcheck_sdelay", "8", "Delay after spawning to perform bot ground check");
-	mBot_MaxDistance	= CreateConVar("sm_mbot_bdistance", "300", "Distance player must be away from bot to pull them");
-	mBot_RetryDelay		= CreateConVar("sm_mbot_bdistance", "8", "Delay player must wait before performing pulls");
+	AutoExecConfig_SetCreateFile(true);
+	AutoExecConfig_SetFile("nd_pull_bot");
+	
+	gCheck_BunkerDistance	= AutoExecConfig_CreateConVar("sm_gcheck_bdistance", "1500", "Distance away from bunker spawn must be to use feature");
+	gCheck_SpawnDelay 	= AutoExecConfig_CreateConVar("sm_gcheck_sdelay", "8", "Delay after spawning to perform bot ground check");
+	mBot_MaxDistance	= AutoExecConfig_CreateConVar("sm_mbot_bdistance", "300", "Distance player must be away from bot to pull them");
+	mBot_RetryDelay		= AutoExecConfig_CreateConVar("sm_mbot_pdelay", "8", "Delay player must wait before performing pulls");
+	
+	AutoExecConfig_EC_File();
+}
+
+void AutoExecConfig_EC_File()
+{
+	// Execute and clean the cfg file
+	AutoExecConfig_ExecuteFile();	
+	AutoExecConfig_CleanFile();
 }

--- a/addons/sourcemod/scripting/nd_pull_bot.sp
+++ b/addons/sourcemod/scripting/nd_pull_bot.sp
@@ -71,10 +71,3 @@ void CreatePluginConvars()
 	
 	AutoExecConfig_EC_File();
 }
-
-void AutoExecConfig_EC_File()
-{
-	// Execute and clean the cfg file
-	AutoExecConfig_ExecuteFile();	
-	AutoExecConfig_CleanFile();
-}


### PR DESCRIPTION
- Fix string typo with bot pull delay

- Use AutoExecConfig wrapper to update cfg files.