### PR TITLE
Remove manual team-pick finish

### DIFF
--- a/addons/sourcemod/scripting/nd_team_pick/picking_process.sp
+++ b/addons/sourcemod/scripting/nd_team_pick/picking_process.sp
@@ -61,7 +61,7 @@ public Handle_PickPlayerMenu(Handle:menu, MenuAction:action, param1, param2)
 			}
 			
 			// If picking is not done, display menu to opposite team incase a skip was sent
-			else if (!PickingComplete())
+			else
 			{
 				SetPickingTeam(); // Decide which team gets the next pick
 				Menu_PlayerPick(next_comm);

--- a/addons/sourcemod/scripting/nd_team_pick/picking_process.sp
+++ b/addons/sourcemod/scripting/nd_team_pick/picking_process.sp
@@ -24,10 +24,8 @@ public Handle_PickPlayerMenu(Handle:menu, MenuAction:action, param1, param2)
 			GetMenuItem(menu, param2, selectedItem, sizeof(selectedItem));	
 			
 			int selectedPlayer = StringToInt(selectedItem);
-			int client = GetClientOfUserId(selectedPlayer);				
-		
-			last_choice[cur_team_choosing - 2] = selectedPlayer;
-			
+			int client = GetClientOfUserId(selectedPlayer);			
+
 			if (DebugTeamPicking)
 			{
 				char message[32];
@@ -48,17 +46,13 @@ public Handle_PickPlayerMenu(Handle:menu, MenuAction:action, param1, param2)
 
 					// Set the player's team to the team captain's team.
 					ChangeClientTeam(client, cur_team_choosing);
-					
-					// Send the team picking menu to the next captain
-					Menu_PlayerPick(next_comm);
 				}
 				
 				// If the picking is not done, continue displaying the menu to pick players.
-				else if (!PickingComplete())
-					Menu_PlayerPick(next_comm);
+				Menu_PlayerPick(next_comm);
 			}
 			
-			// If selected item was a player, refresh to pick anther option.
+			// If selected item wasn't a player, refresh to pick anther option.
 			else if (selectedPlayer != NO_PLAYER_SELECTED)
 			{
 				PrintMessage(client, "Pick Again");
@@ -81,15 +75,10 @@ public Handle_PickPlayerMenu(Handle:menu, MenuAction:action, param1, param2)
 				ConsoleToAdmins("Handle_PickPlayerMenu(): MenuAction_Cancel", "b");
 			
 			// Switch to the other team and set their last choice to canceled
-			SetPickingTeam();
-			//SwitchPickingTeam();			
-			
-			if (!lastTimerEnded || noChoiceFound)
-				last_choice[cur_team_choosing - 2] = NO_PLAYER_SELECTED;
+			SetPickingTeam(); //SwitchPickingTeam();
 
 			// If the picking is not done, continue displaying the menu to pick players.
-			if (!PickingComplete())
-				CreateTimer(3.0, TIMER_DelayNextPick, _, TIMER_FLAG_NO_MAPCHANGE);
+			CreateTimer(3.0, TIMER_DelayNextPick, _, TIMER_FLAG_NO_MAPCHANGE);
 		}
 	}
 
@@ -251,17 +240,6 @@ void PrintPickOrderMessage(char[] phrase, int team)
 	}	
 }
 
-bool PickingComplete()
-{
-	if (	last_choice[CONSORT_aIDX] == NO_PLAYER_SELECTED && 	
-		last_choice[EMPIRE_aIDX] == NO_PLAYER_SELECTED)
-	{
-		FinishPicking();			
-		return true;
-	}
-	
-	return false;
-}
 void FinishPicking(bool forced = false)
 {
 	g_bEnabled = false;

--- a/addons/sourcemod/scripting/nd_team_pick/picking_timer.sp
+++ b/addons/sourcemod/scripting/nd_team_pick/picking_timer.sp
@@ -1,7 +1,6 @@
 #define INVALID_USERID 0
 #define NO_PLAYERS_LEFT 0
 bool lastTimerEnded = false;
-bool noChoiceFound = false;
 int PickTimeRemaining = 0;
 Handle hPickTimerHandler = INVALID_HANDLE;
 
@@ -110,12 +109,8 @@ void AutoSelectPlayer(int picker)
 		// Print the auto assignment to server chat
 		PrintAutoSelected(playerToSelect, team);
 	}
-	else 
-	{
-		noChoiceFound = true;
-		if (DebugTeamPicking)
-			ConsoleToAdmins( "AutoSelectPlayer(): Didn't find anybody", "b");
-	}
+	else if (DebugTeamPicking) 
+		ConsoleToAdmins( "AutoSelectPlayer(): Didn't find anybody", "b");
 }
 
 void PrintAutoSelected(int player, int team)

--- a/addons/sourcemod/scripting/nd_team_pick/start_picking.sp
+++ b/addons/sourcemod/scripting/nd_team_pick/start_picking.sp
@@ -149,9 +149,6 @@ void PrintPickingMessages()
 
 void SetVarriableDefaults()
 {
-	last_choice[CONSORT_aIDX] = 0;
-	last_choice[EMPIRE_aIDX] = 0;
-	
 	team_captain[CONSORT_aIDX] = -1;
 	team_captain[EMPIRE_aIDX] = -1;
 	

--- a/addons/sourcemod/scripting/nd_team_picking.sp
+++ b/addons/sourcemod/scripting/nd_team_picking.sp
@@ -17,7 +17,6 @@ public Plugin myinfo =
 #define CONSORT_aIDX 0
 #define EMPIRE_aIDX 1
 
-int last_choice[2];
 int team_captain[2];
 
 bool g_bEnabled = false;


### PR DESCRIPTION
- This process is automated now. Manual allows commanders to exploit an early finish by sending cancel.