### PR TITLE
Fix regression with skill base modifications

### DIFF
--- a/addons/sourcemod/scripting/nd_gameme_skill.sp
+++ b/addons/sourcemod/scripting/nd_gameme_skill.sp
@@ -35,7 +35,7 @@ public Plugin myinfo =
 	name = "[ND] GameMe Skill Calculator",
 	author = "Stickz",
 	description = "Creates a skill level based on each player's GameME data.",
-	version = "recompile",
+	version = "dummy",
 	url = "https://github.com/stickz/Redstone"
 };
 

--- a/addons/sourcemod/scripting/nd_gskill/gameme/kill_stats.sp
+++ b/addons/sourcemod/scripting/nd_gskill/gameme/kill_stats.sp
@@ -101,7 +101,7 @@ float GameME_GetModifiedSkillBase(int client)
 	float ClientHpk = GameME_GetModifiedHpk(client, true);
 	float ClientMinHpk = percentToDecimal(gc_GameMe[hpkMiddleTendency].FloatValue);
 	
-	if (ClientHpk < ClientMinHpk)
+	if (ClientHpk < ClientMinHpk && GameME_UseHPK_Modifier(client))
 	{
 		// calculate the percent taken off for every hpk percent missing
 		float ClientHpkMod = (ClientMinHpk - ClientHpk) * gc_GameMe[hpkSkillBaseModifer].FloatValue;


### PR DESCRIPTION
- The max hpk was reducing new level 80's to 64, before that stat had enough time to develop.