### PR TITLE
Integrate steam group into server

### DIFF
--- a/addons/sourcemod/scripting/include/nd_swgm.inc
+++ b/addons/sourcemod/scripting/include/nd_swgm.inc
@@ -77,7 +77,7 @@ native void SWGM_CheckPlayers();
 public SharedPlugin __pl_SWGM= 
 {
 	name = "SWGM",
-	file = "SWGM.smx",
+	file = "nd_swgm.smx",
 	required = 0
 };
 

--- a/addons/sourcemod/scripting/include/nd_swgm.inc
+++ b/addons/sourcemod/scripting/include/nd_swgm.inc
@@ -38,6 +38,7 @@ forward void SWGM_OnLeaveGroup(int iClient);
  *  @error                  Invalid client index, client not in game, or client bot.
  */
 native bool SWGM_InGroup(int iClient);
+#define SWGM_IG_AVAILIBLE() (GetFeatureStatus(FeatureType_Native, "SWGM_InGroup") == FeatureStatus_Available)
 
 /**
  *  Check is player in group and officer.

--- a/addons/sourcemod/scripting/include/nd_swgm.inc
+++ b/addons/sourcemod/scripting/include/nd_swgm.inc
@@ -40,6 +40,10 @@ forward void SWGM_OnLeaveGroup(int iClient);
 native bool SWGM_InGroup(int iClient);
 #define SWGM_IG_AVAILIBLE() (GetFeatureStatus(FeatureType_Native, "SWGM_InGroup") == FeatureStatus_Available)
 
+stock bool SWGM_IsInGroup(int iClient, bool default = true) {
+	return !SWGM_IG_AVAILIBLE() ? default : SWGM_InGroup(iClient);
+}
+
 /**
  *  Check is player in group and officer.
  *

--- a/addons/sourcemod/scripting/include/nd_swgm.inc
+++ b/addons/sourcemod/scripting/include/nd_swgm.inc
@@ -40,8 +40,8 @@ forward void SWGM_OnLeaveGroup(int iClient);
 native bool SWGM_InGroup(int iClient);
 #define SWGM_IG_AVAILIBLE() (GetFeatureStatus(FeatureType_Native, "SWGM_InGroup") == FeatureStatus_Available)
 
-stock bool SWGM_IsInGroup(int iClient, bool default = true) {
-	return !SWGM_IG_AVAILIBLE() ? default : SWGM_InGroup(iClient);
+stock bool SWGM_IsInGroup(int iClient, bool bDefault) {
+	return !SWGM_IG_AVAILIBLE() ? bDefault : SWGM_InGroup(iClient);
 }
 
 /**

--- a/addons/sourcemod/scripting/include/nd_swgm.inc
+++ b/addons/sourcemod/scripting/include/nd_swgm.inc
@@ -78,14 +78,9 @@ public SharedPlugin __pl_SWGM=
 {
 	name = "SWGM",
 	file = "SWGM.smx",
-#if defined REQUIRE_PLUGIN
-	required = 1
-#else
 	required = 0
-#endif
 };
 
-#if !defined REQUIRE_PLUGIN
 public __pl_SWGM_SetNTVOptional()
 {
 	MarkNativeAsOptional("SWGM_InGroup");
@@ -94,4 +89,3 @@ public __pl_SWGM_SetNTVOptional()
 	MarkNativeAsOptional("SWGM_CheckPlayer");
 	MarkNativeAsOptional("SWGM_CheckPlayers");
 }
-#endif

--- a/addons/sourcemod/scripting/nd_advertise.sp
+++ b/addons/sourcemod/scripting/nd_advertise.sp
@@ -44,7 +44,7 @@ public Action TIMER_AdvertiseSteamGroup(Handle timer)
 void PrintSteamGroupAdvert(const char[] phrase)
 {
 	for (int client = 1; client <= MaxClients; client++) {
-		if (IsValidClient(client) && option_adverts[client] && !SWGM_IsInGroup(client)) {
+		if (IsValidClient(client) && option_adverts[client] && !SWGM_IsInGroup(client, false)) {
 			PrintMessageEx(client, phrase);
 		}
 	}

--- a/addons/sourcemod/scripting/nd_advertise.sp
+++ b/addons/sourcemod/scripting/nd_advertise.sp
@@ -89,10 +89,14 @@ public CookieMenuHandler_ServerAverts(int client, CookieMenuAction:action, any:i
 		
 		case CookieMenuAction_SelectOption:
 		{
-			option_adverts[client] = !option_adverts[client];		
+			if (option_adverts[client] && !SWGM_IsInGroup(client, true))
+				PrintMessage(client, "Steam Group Usage");
+			else
+				option_adverts[client] = !option_adverts[client];			
+
 			SetClientCookie(client, cookie_adverts, option_adverts[client] ? "On" : "Off");		
 			ShowCookieMenu(client);		
-		}	
+		}
 	}
 }
 
@@ -105,5 +109,5 @@ bool GetCookieAdverts(int client)
 	char buffer[10];
 	GetClientCookie(client, cookie_adverts, buffer, sizeof(buffer));
 	
-	return !StrEqual(buffer, "Off");
+	return !SWGM_IsInGroup(client, true) ? "On" : !StrEqual(buffer, "Off");
 }

--- a/addons/sourcemod/scripting/nd_advertise.sp
+++ b/addons/sourcemod/scripting/nd_advertise.sp
@@ -100,6 +100,11 @@ public CookieMenuHandler_ServerAverts(int client, CookieMenuAction:action, any:i
 	}
 }
 
+// Enable advertisments, if the client leaves the steam group
+public void SWGM_OnLeaveGroup(int client) {
+	option_adverts[client] = true;
+}
+
 public void OnClientCookiesCached(int client) {
 	option_adverts[client] = GetCookieAdverts(client);
 }

--- a/addons/sourcemod/scripting/nd_advertise.sp
+++ b/addons/sourcemod/scripting/nd_advertise.sp
@@ -109,5 +109,5 @@ bool GetCookieAdverts(int client)
 	char buffer[10];
 	GetClientCookie(client, cookie_adverts, buffer, sizeof(buffer));
 	
-	return !SWGM_IsInGroup(client, true) ? "On" : !StrEqual(buffer, "Off");
+	return !SWGM_IsInGroup(client, true) ? true : !StrEqual(buffer, "Off");
 }

--- a/addons/sourcemod/scripting/nd_advertise.sp
+++ b/addons/sourcemod/scripting/nd_advertise.sp
@@ -3,6 +3,7 @@
 #include <nd_print>
 #include <nd_stocks>
 #include <clientprefs>
+#include <nd_swgm>
 
 public Plugin myinfo =
 {
@@ -35,19 +36,28 @@ public void ND_OnTeamsShuffled() {
 public Action TIMER_AdvertiseSteamGroup(Handle timer)
 {
 	// Join the RedstoneND steam group!
-	PrintServerAdvert("Join RedstoneND");
+	PrintSteamGroupAdvert("Join RedstoneND");
 	
 	return Plugin_Handled;
 }
 
-void PrintServerAdvert(const char[] phrase)
+void PrintSteamGroupAdvert(const char[] phrase)
+{
+	for (int client = 1; client <= MaxClients; client++) {
+		if (IsValidClient(client) && option_adverts[client] && !SWGM_IsInGroup(client)) {
+			PrintMessageEx(client, phrase);
+		}
+	}
+}
+
+/*void PrintServerAdvert(const char[] phrase)
 {
 	for (int client = 1; client <= MaxClients; client++) {
 		if (IsValidClient(client) && option_adverts[client]) {
 			PrintMessageEx(client, phrase);
 		}
 	}
-}
+}*/
 
 public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
 {

--- a/addons/sourcemod/scripting/nd_grenade_trails_deux.sp
+++ b/addons/sourcemod/scripting/nd_grenade_trails_deux.sp
@@ -7,6 +7,7 @@
 #include <nd_rounds>
 #include <nd_com_eng>
 #include <nd_redstone>
+#include <nd_swgm>
 
 #define NO_COMMANDER -1
 #define MAX_DISPLAYNAME_SIZE 30

--- a/addons/sourcemod/scripting/nd_grenade_trails_deux.sp
+++ b/addons/sourcemod/scripting/nd_grenade_trails_deux.sp
@@ -8,6 +8,7 @@
 #include <nd_com_eng>
 #include <nd_redstone>
 #include <nd_swgm>
+#include <nd_print>
 
 #define NO_COMMANDER -1
 #define MAX_DISPLAYNAME_SIZE 30
@@ -50,6 +51,7 @@ public void OnPluginStart()
 		PrecacheTrails();
 	
 	LoadTranslations("nd_grenade_trails_deux.phrases");
+	LoadTranslations("nd_common.phrases");
 	AddClientPrefSupport(); // clientprefs.sp
 	AddUpdaterLibrary(); //auto-updater
 }

--- a/addons/sourcemod/scripting/nd_trails/clientprefs.sp
+++ b/addons/sourcemod/scripting/nd_trails/clientprefs.sp
@@ -35,6 +35,11 @@ public CookieMenuHandler_Trails(int client, CookieMenuAction:action, any:info, S
 	}
 }
 
+// Disable trails, if the client leaves the steam group
+public void SWGM_OnLeaveGroup(int iClient) {
+	option_trails[client] = false;
+}
+
 public void OnClientCookiesCached(int client) {
 	option_trails[client] = GetCookieTrails(client);
 }

--- a/addons/sourcemod/scripting/nd_trails/clientprefs.sp
+++ b/addons/sourcemod/scripting/nd_trails/clientprefs.sp
@@ -36,7 +36,7 @@ public CookieMenuHandler_Trails(int client, CookieMenuAction:action, any:info, S
 }
 
 // Disable trails, if the client leaves the steam group
-public void SWGM_OnLeaveGroup(int iClient) {
+public void SWGM_OnLeaveGroup(int client) {
 	option_trails[client] = false;
 }
 

--- a/addons/sourcemod/scripting/nd_trails/clientprefs.sp
+++ b/addons/sourcemod/scripting/nd_trails/clientprefs.sp
@@ -22,8 +22,14 @@ public CookieMenuHandler_Trails(int client, CookieMenuAction:action, any:info, S
 		
 		case CookieMenuAction_SelectOption:
 		{
-			option_trails[client] = !option_trails[client];		
-			SetClientCookie(client, cookie_trails, option_trails[client] ? "On" : "Off");		
+			if (!option_trails[client] && !SWGM_IsInGroup(client, true))
+				PrintMessage(client, "Steam Group Usage");
+			else
+			{
+				option_trails[client] = !option_trails[client];		
+				SetClientCookie(client, cookie_trails, option_trails[client] ? "On" : "Off");			
+			}
+		
 			ShowCookieMenu(client);		
 		}	
 	}
@@ -38,5 +44,5 @@ bool GetCookieTrails(int client)
 	char buffer[10];
 	GetClientCookie(client, cookie_trails, buffer, sizeof(buffer));
 	
-	return !StrEqual(buffer, "Off");
+	return !StrEqual(buffer, "Off") && SWGM_IsInGroup(client, true);
 }

--- a/updater/nd_translation_updater/translations/nd_common.phrases.txt
+++ b/updater/nd_translation_updater/translations/nd_common.phrases.txt
@@ -1,6 +1,6 @@
 "Phrases"
 {
-    "Empire"
+   	"Empire"
 	{
 		"en"		"Empire"
 	}
@@ -33,5 +33,10 @@
 	"On Team"
 	{
 		"en"		"You must be on a team to use this command"
+	}
+	
+	"Steam Group Usage"
+	{
+		"en"		"You must join the RedstoneND steam group to use this feature"
 	}
 }


### PR DESCRIPTION
- Only display steam group advertisements for people not in the steam group

- Require players to join the RedstoneND steam group to disable server adverts.

- Require players to join the RedstoneND steam group to use grenade trails.