### PR TITLE
Improve nd_commander_chair plugin

### DIFF
--- a/addons/sourcemod/scripting/nd_commander_chair.sp
+++ b/addons/sourcemod/scripting/nd_commander_chair.sp
@@ -89,7 +89,7 @@ public Action TIMER_EnterChairDelay(Handle timer)
 
 public Action ND_OnCommanderEnterChair(int client, int team)
 {	
-	if (!ChairWaitTimeElapsed && RED_OnTeamCount() > cvarMinPlys.IntValue && !ND_InitialCommandersReady(true))
+	if (!ChairWaitTimeElapsed && RED_OnTeamCount() >= cvarMinPlys.IntValue && !ND_InitialCommandersReady(true))
 	{
 		PrintMessage(client, "Wait Enter Chair");
 		return Plugin_Handled;

--- a/addons/sourcemod/scripting/nd_commander_chair.sp
+++ b/addons/sourcemod/scripting/nd_commander_chair.sp
@@ -41,6 +41,8 @@ public Plugin myinfo =
 
 ConVar cvarMinPlys;
 ConVar cvarMaxTime;
+ConVar cvarSelectMin;
+ConVar cvarSelectMax;
 
 bool ChairWaitTimeElapsed = false;
 
@@ -63,6 +65,10 @@ public void ND_OnRoundStarted()
 {
 	ChairWaitTimeElapsed = false;
 	BunkerDelayTimer = CreateTimer(cvarMaxTime.FloatValue, TIMER_EnterChairDelay, _, TIMER_FLAG_NO_MAPCHANGE);
+	
+	// If we have enough players, set commander selection time to min; otherwise, set it to max.
+	int selectTime = RED_OnTeamCount() >= cvarMinPlys.IntValue ? cvarSelectMin.IntValue : cvarSelectMax.IntValue;
+	ServerCommand("sm_cvar nd_commander_election_time %d", selectTime);
 }
 
 public void ND_OnRoundEnded() 
@@ -104,6 +110,8 @@ void CreatePluginConvars()
 	
 	cvarMinPlys		=	AutoExecConfig_CreateConVar("sm_chair_plys", "8", "Min number of players on a team required to block the command chair");
 	cvarMaxTime		= 	AutoExecConfig_CreateConVar("sm_chair_max", "120", "How long should we block chair if nobody applies for commander?");
+	cvarSelectMin		=	AutoExecConfig_CreateConVar("sm_chair_select_min", "15", "Duration to wait to select commanders, with chair blocking");
+	cvarSelectMax		=	AutoExecConfig_CreateConVar("sm_chair_select_max", "30", "Duration to wait to select commanders, without chair blocks");
 	
 	AutoExecConfig_EC_File();
 }

--- a/addons/sourcemod/scripting/nd_commander_chair.sp
+++ b/addons/sourcemod/scripting/nd_commander_chair.sp
@@ -54,6 +54,9 @@ public void OnPluginStart()
 	LoadTranslations("nd_commander_chair.phrases");
 	
 	AddUpdaterLibrary(); //auto-updater
+	
+	// If the plugin loads late, disable the chair waiting
+	ChairWaitTimeElapsed = ND_RoundStarted();
 }
 
 public void ND_OnRoundStarted() 


### PR DESCRIPTION
- Fix late loading support when the plugin is reloaded middle match.

- Fix operator not properly checking the minimum the player count,

- Set 15s commander selection time with greater than min players.

- Set 30s commander selection time with less than min players.