### PR TITLE
Improve Round Engine

### DIFF
--- a/addons/sourcemod/scripting/include/nd_rounds.inc
+++ b/addons/sourcemod/scripting/include/nd_rounds.inc
@@ -81,14 +81,15 @@ native bool ND_RoundRestartable();
 native void ND_RestartRound(bool toWarmup);
 
 /* Round engine forwards */
-forward void ND_OnRoundStart();
+forward void ND_OnPreRoundStart();
 forward void ND_OnRoundStarted();
-
-forward void ND_OnRoundEnd();
 forward void ND_OnRoundEnded();
 
-/* Only fires if the round has started this map */
+// Only fires if the round has started this map
 forward void ND_OnRoundEndedEX();
 
-/* Fires the RoundEnd forward to all plugins */
-native void ND_SimulateRoundEnd()
+// Simulate the round ending to contact other plugins
+native void ND_SimulateRoundEnd();
+
+// Start the round and contact other plugins beforehand
+native void ND_PerformRoundStart();

--- a/addons/sourcemod/scripting/nd_commander_chair.sp
+++ b/addons/sourcemod/scripting/nd_commander_chair.sp
@@ -61,14 +61,17 @@ public void OnPluginStart()
 	ChairWaitTimeElapsed = ND_RoundStarted();
 }
 
+public void ND_OnPreRoundStart()
+{
+	// If we have enough players, set commander selection time to min; otherwise, set it to max.
+	int selectTime = RED_OnTeamCount() >= cvarMinPlys.IntValue ? cvarSelectMin.IntValue : cvarSelectMax.IntValue;
+	ServerCommand("sm_cvar nd_commander_election_time %d", selectTime);
+}
+
 public void ND_OnRoundStarted() 
 {
 	ChairWaitTimeElapsed = false;
 	BunkerDelayTimer = CreateTimer(cvarMaxTime.FloatValue, TIMER_EnterChairDelay, _, TIMER_FLAG_NO_MAPCHANGE);
-	
-	// If we have enough players, set commander selection time to min; otherwise, set it to max.
-	int selectTime = RED_OnTeamCount() >= cvarMinPlys.IntValue ? cvarSelectMin.IntValue : cvarSelectMax.IntValue;
-	ServerCommand("sm_cvar nd_commander_election_time %d", selectTime);
 }
 
 public void ND_OnRoundEnded() 

--- a/addons/sourcemod/scripting/nd_round_engine.sp
+++ b/addons/sourcemod/scripting/nd_round_engine.sp
@@ -37,6 +37,7 @@ bool roundEnded = false;
 bool mapStarted = false;
 
 Handle g_OnRoundStartedForward;
+Handle g_OnRoundStartEXForward;
 Handle g_OnRoundEndedForward;
 Handle g_OnRoundEndedEXForward;
 
@@ -46,6 +47,7 @@ public void OnPluginStart()
 	HookEvent("round_win", Event_RoundEnd, EventHookMode_PostNoCopy);
 	
 	g_OnRoundStartedForward = CreateGlobalForward("ND_OnRoundStarted", ET_Ignore);
+	g_OnRoundStartEXForward = CreateGlobalForward("ND_OnPreRoundStart", ET_Ignore);
 	g_OnRoundEndedForward = CreateGlobalForward("ND_OnRoundEnded", ET_Ignore);
 	g_OnRoundEndedEXForward = CreateGlobalForward("ND_OnRoundEndedEX", ET_Ignore);
 	
@@ -134,6 +136,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 
 	CreateNative("ND_MapStarted", Native_GetMapStarted)
 	
+	CreateNative("ND_PerformRoundStart", Native_FireRoundStart);
 	CreateNative("ND_SimulateRoundEnd", Native_FireRoundEnd);
 	CreateNative("ND_RestartRound", Native_FireRoundRestart);
 	return APLRes_Success;
@@ -157,6 +160,15 @@ public int Native_GetMapStarted(Handle plugin, int numParams) {
 
 public int Native_GetRoundRestartable(Handle plugin, int numParams) {
 	return _:(roundStarted && roundCanBeRestarted && !roundRestartPending);
+}
+
+public int Native_FireRoundStart(Handle plugin, int numParams)
+{
+	Action dummy;
+	Call_StartForward(g_OnRoundStartEXForward);
+	Call_Finish(dummy);
+	
+	ServerCommand("mp_minplayers 1");
 }
 
 public int Native_FireRoundEnd(Handle plugin, int numParams) {

--- a/addons/sourcemod/scripting/nd_round_start.sp
+++ b/addons/sourcemod/scripting/nd_round_start.sp
@@ -106,5 +106,6 @@ void StartRound(bool balance = false)
 	else
 		PrintToChatAll("\x05[TB] %t", "Balancer Off");
 	
-	ServerCommand("mp_minplayers 1");
+	// Fires mp_minplayers 1, but contacts other plugins first
+	ND_PerformRoundStart();
 }


### PR DESCRIPTION
- Remove dead forwards that do not perform any actions.

- Fire a forward before performing a normal round start.

- Fix a bug where commander election times must be set before round start.