### PR TITLE
Improve Chair Block Feature

### DIFF
--- a/addons/sourcemod/scripting/nd_commander_chair.sp
+++ b/addons/sourcemod/scripting/nd_commander_chair.sp
@@ -41,13 +41,16 @@ public Plugin myinfo =
 
 ConVar cvarMinTeam;
 ConVar cvarMinTotal;
-ConVar cvarMaxTime;
+ConVar cvarMaxRStart;
+ConVar cvarMaxPromote;
 ConVar cvarSelectMin;
 ConVar cvarSelectMax;
 
-bool ChairWaitTimeElapsed = false;
+bool ChairWaitRStartElapsed = false;
+bool ChairWaitPromoteElapsed[2] = { false, ...};
 
 Handle BunkerDelayTimer = INVALID_HANDLE;
+Handle PromoteDelayTimer[2] = { INVALID_HANDLE, ...};
 
 public void OnPluginStart()
 {
@@ -59,7 +62,9 @@ public void OnPluginStart()
 	AddUpdaterLibrary(); //auto-updater
 	
 	// If the plugin loads late, disable the chair waiting
-	ChairWaitTimeElapsed = ND_RoundStarted();
+	bool rStart = ND_RoundStarted();	
+	ToggleWaitPromote(rStart);
+	ChairWaitRStartElapsed = rStart;
 }
 
 public void ND_OnPreRoundStart()
@@ -71,24 +76,40 @@ public void ND_OnPreRoundStart()
 
 public void ND_OnRoundStarted() 
 {
-	ChairWaitTimeElapsed = false;
-	BunkerDelayTimer = CreateTimer(cvarMaxTime.FloatValue, TIMER_EnterChairDelay, _, TIMER_FLAG_NO_MAPCHANGE);
+	ToggleWaitPromote(false);
+	ChairWaitRStartElapsed = false;
+	BunkerDelayTimer = CreateTimer(cvarMaxRStart.FloatValue, TIMER_EnterChairRStartDelay, _, TIMER_FLAG_NO_MAPCHANGE);
 }
 
 public void ND_OnRoundEnded() 
 {
 	if (BunkerDelayTimer != INVALID_HANDLE && IsValidHandle(BunkerDelayTimer))
 		CloseHandle(BunkerDelayTimer);
+	
+	for (int h = 0; h < 2; h++) {
+		if (PromoteDelayTimer[h] != INVALID_HANDLE && IsValidHandle(PromoteDelayTimer[h])) {
+			CloseHandle(PromoteDelayTimer[h]);
+		}
+	}
+}
+
+public void ND_OnCommanderPromoted(int client, int team)
+{
+	PromoteDelayTimer[team-2] = CreateTimer(cvarMaxRStart.FloatValue, TIMER_EnterChairPromoteDelay, 
+						GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE);
 }
 
 public void ND_BothCommandersPromoted(int consort, int empire)
 {
 	// Show early chair unlock message
-	if (!ChairWaitTimeElapsed)
+	if (!ChairWaitRStartElapsed)
+	{
+		ToggleWaitPromote(true);
 		PrintMessageAll("Chair Unlocked");
+	}
 }
 
-public Action TIMER_EnterChairDelay(Handle timer) 
+public Action TIMER_EnterChairRStartDelay(Handle timer)
 {
 	ChairWaitTimeElapsed = true;
 	
@@ -97,14 +118,38 @@ public Action TIMER_EnterChairDelay(Handle timer)
 		PrintMessageAll("Wait Enter Expired");
 }
 
+public Action TIMER_EnterChairPromoteDelay(Handle timer)
+{
+	// Get client and check if userid is valid
+	int client = GetClientOfUserId(userid);		
+	if (client == INVALID_USERID)
+		return Plugin_Handled;
+	
+	// Set the promote wait elapsed to true
+	int team = GetClientTeam(client);
+	ChairWaitPromoteElapsed[team-2] = true;
+	
+	// Show chair lock expire message, if commanders aren't selected in-time
+	if (!ND_InitialCommandersReady(true))
+		PrintMessage(client, "Wait Promote Expired");
+}
+
 public Action ND_OnCommanderEnterChair(int client, int team)
 {	
-	if (!ChairWaitTimeElapsed && ChairBlockThresholdReached() && !ND_InitialCommandersReady(true))
+	if (!ND_InitialCommandersReady(true) && ChairBlockThresholdReached())
 	{
-		PrintMessage(client, "Wait Enter Chair");
-		return Plugin_Handled;
+		if (!ChairWaitRStartElapsed)
+		{
+			PrintMessageTI1(client, "Wait Enter Chair", cvarMaxRStart.IntValue);
+			return Plugin_Handled;
+		}
+		else if (!ChairWaitPromoteElapsed[team-2])
+		{
+			PrintMessageTI1(client, "Wait Enter Chair", cvarMaxPromote.IntValue);
+			return Plugin_Handled;
+		}
 	}
-		
+
 	return Plugin_Continue;
 }
 
@@ -114,13 +159,20 @@ bool ChairBlockThresholdReached()
 		ND_GetClientCount() >= cvarMinTotal.IntValue;
 }
 
+void ToggleWaitPromote(bool value)
+{
+	ChairWaitPromoteElapsed[0] = value
+	ChairWaitPromoteElapsed[1] = value
+}
+
 void CreatePluginConvars()
 {
 	AutoExecConfig_Setup("nd_commander_chair");
 	
 	cvarMinTeam		=	AutoExecConfig_CreateConVar("sm_chair_block_team", "8", "Min number of players on a team required to block the command chair");
 	cvarMinTotal		=	AutoExecConfig_CreateConVar("sm_chair_block_total", "12", "Min number of total players required to block the command chair");
-	cvarMaxTime		= 	AutoExecConfig_CreateConVar("sm_chair_max", "120", "How long should we block chair if nobody applies for commander?");
+	cvarMaxRStart		= 	AutoExecConfig_CreateConVar("sm_chair_max_rstart", "120", "How long to block chair after round start if nobody applies for commander?");
+	cvarMaxPromote		= 	AutoExecConfig_CreateConVar("sm_chair_max_promote", "60", "How long to block chair after promotion if nobody applies for commander?");	
 	cvarSelectMin		=	AutoExecConfig_CreateConVar("sm_chair_select_min", "15", "Duration to wait to select commanders, with chair blocking");
 	cvarSelectMax		=	AutoExecConfig_CreateConVar("sm_chair_select_max", "30", "Duration to wait to select commanders, without chair blocks");
 	

--- a/addons/sourcemod/scripting/nd_commander_chair.sp
+++ b/addons/sourcemod/scripting/nd_commander_chair.sp
@@ -19,12 +19,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #include "updater/standard.sp"
 
 #include <sourcemod>
+#include <autoexecconfig>
 #include <sdktools>
 #include <nd_stocks>
-#include <autoexecconfig>
-
-#pragma newdecls required
-
 #include <nd_com_eng>
 #include <nd_redstone>
 #include <nd_rounds>

--- a/addons/sourcemod/scripting/nd_commander_chair.sp
+++ b/addons/sourcemod/scripting/nd_commander_chair.sp
@@ -108,14 +108,16 @@ public void ND_BothCommandersPromoted(int consort, int empire)
 
 public Action TIMER_EnterChairRStartDelay(Handle timer)
 {
-	ChairWaitTimeElapsed = true;
+	ChairWaitRStartElapsed = true;
 	
 	// Show chair lock expire message, if commanders aren't selected in-time
 	if (!ND_InitialCommandersReady(true))
 		NotifyCommandersOfChairUnlock("May Enter Chair");
+		
+	return Plugin_Continue;
 }
 
-public Action TIMER_EnterChairPromoteDelay(Handle timer)
+public Action TIMER_EnterChairPromoteDelay(Handle timer, any:userid)
 {
 	// Get client and check if userid is valid
 	int client = GetClientOfUserId(userid);		
@@ -129,6 +131,8 @@ public Action TIMER_EnterChairPromoteDelay(Handle timer)
 	// Show chair lock expire message, if commanders aren't selected in-time
 	if (!ND_InitialCommandersReady(true) && ChairWaitRStartElapsed)
 		PrintMessage(client, "May Enter Chair");
+		
+	return Plugin_Continue;
 }
 
 public Action ND_OnCommanderEnterChair(int client, int team)

--- a/addons/sourcemod/scripting/nd_commander_chair.sp
+++ b/addons/sourcemod/scripting/nd_commander_chair.sp
@@ -103,10 +103,7 @@ public void ND_BothCommandersPromoted(int consort, int empire)
 {
 	// Show early chair unlock message
 	if (!ChairWaitRStartElapsed)
-	{
-		ToggleWaitPromote(true);
 		PrintMessageAll("Chair Unlocked");
-	}
 }
 
 public Action TIMER_EnterChairRStartDelay(Handle timer)

--- a/addons/sourcemod/scripting/nd_commander_chair.sp
+++ b/addons/sourcemod/scripting/nd_commander_chair.sp
@@ -103,7 +103,7 @@ public void ND_BothCommandersPromoted(int consort, int empire)
 {
 	// Show early chair unlock message
 	if (!ChairWaitRStartElapsed)
-		PrintMessageAll("Chair Unlocked");
+		NotifyCommandersOfChairUnlock("Chair Unlocked");
 }
 
 public Action TIMER_EnterChairRStartDelay(Handle timer)
@@ -112,7 +112,7 @@ public Action TIMER_EnterChairRStartDelay(Handle timer)
 	
 	// Show chair lock expire message, if commanders aren't selected in-time
 	if (!ND_InitialCommandersReady(true))
-		PrintMessageAllTI1("Wait Enter Expired", cvarMaxRStart.IntValue);
+		NotifyCommandersOfChairUnlock("May Enter Chair");
 }
 
 public Action TIMER_EnterChairPromoteDelay(Handle timer)
@@ -127,8 +127,8 @@ public Action TIMER_EnterChairPromoteDelay(Handle timer)
 	ChairWaitPromoteElapsed[team-2] = true;
 	
 	// Show chair lock expire message, if commanders aren't selected in-time
-	if (!ND_InitialCommandersReady(true))
-		PrintMessage(client, "Wait Promote Expired");
+	if (!ND_InitialCommandersReady(true) && ChairWaitRStartElapsed)
+		PrintMessage(client, "May Enter Chair");
 }
 
 public Action ND_OnCommanderEnterChair(int client, int team)
@@ -158,8 +158,21 @@ bool ChairBlockThresholdReached()
 
 void ToggleWaitPromote(bool value)
 {
-	ChairWaitPromoteElapsed[0] = value
-	ChairWaitPromoteElapsed[1] = value
+	ChairWaitPromoteElapsed[0] = value;
+	ChairWaitPromoteElapsed[1] = value;
+}
+
+void NotifyCommandersOfChairUnlock(const char[] phrase)
+{
+	// Send may enter chair to empire commander, if availible
+	int empireCommander = ND_GetCommanderOnTeam(TEAM_EMPIRE);
+	if (empireCommander != -1)
+		PrintMessage(empireCommander, phrase);
+			
+	// Send may enter chair to consort commander, if availible
+	int consortCommander =  ND_GetCommanderOnTeam(TEAM_CONSORT);
+	if (consortCommander != -1)
+		PrintMessage(consortCommander, phrase);
 }
 
 void CreatePluginConvars()

--- a/addons/sourcemod/scripting/nd_commander_chair.sp
+++ b/addons/sourcemod/scripting/nd_commander_chair.sp
@@ -115,7 +115,7 @@ public Action TIMER_EnterChairRStartDelay(Handle timer)
 	
 	// Show chair lock expire message, if commanders aren't selected in-time
 	if (!ND_InitialCommandersReady(true))
-		PrintMessageAll("Wait Enter Expired");
+		PrintMessageAllTI1("Wait Enter Expired", cvarMaxRStart.IntValue);
 }
 
 public Action TIMER_EnterChairPromoteDelay(Handle timer)

--- a/updater/nd_commander_chair/translations/nd_commander_chair.phrases.txt
+++ b/updater/nd_commander_chair/translations/nd_commander_chair.phrases.txt
@@ -6,10 +6,9 @@
 		"en" 		"Please wait {1} seconds or until both teams get a commander"	
 	}
 	
-	"Wait Enter Expired"
+	"May Enter Chair"
 	{
-		"#format"	"{1:i}"
-		"en"		"Command chairs unlocked after {1} seconds"
+		"en"		"Your command chair is now unlocked. Consider waiting for the other team get a commander"
 	}
 	
 	"Chair Unlocked"

--- a/updater/nd_commander_chair/translations/nd_commander_chair.phrases.txt
+++ b/updater/nd_commander_chair/translations/nd_commander_chair.phrases.txt
@@ -8,7 +8,7 @@
 	
 	"May Enter Chair"
 	{
-		"en"		"Your command chair is now unlocked. Consider waiting for the other team get a commander"
+		"en"		"Command chair unlocked. Consider waiting for the other team get a commander"
 	}
 	
 	"Chair Unlocked"


### PR DESCRIPTION
- Set two delays for entering the chair: 120s after round start and 60s after promotion. If one team doesn't have a commander, when the threshold is meant.

- Only notify commanders with messages from this plugin. Contacting other players in unnecessary.

- Resolve multiple syntax errors from the previous version, not catch by the compiler.

- Update phrases file to reflect the new shorter and less complicated phrases.