### PR TITLE
Improve Bot Features

### DIFF
--- a/addons/sourcemod/scripting/nd_bot_feat/convars.sp
+++ b/addons/sourcemod/scripting/nd_bot_feat/convars.sp
@@ -8,9 +8,14 @@ enum convars
 	 ConVar:BotReductionDec,
 	 ConVar:BotDiffMult,
 	 ConVar:BoosterQuota,
+	 
 	 ConVar:DisableBotsAt,
 	 ConVar:DisableBotsAtDec,
 	 ConVar:DisableBotsAtInc,
+	 ConVar:DisableBotsTeam,
+	 ConVar:DisableBotsTeamDec,
+	 ConVar:DisableBotsTeamInc,
+	 
 	 ConVar:BotOverblance,
 	 ConVar:RegOverblance,
 	 ConVar:turretCountDec,
@@ -30,10 +35,15 @@ void CreatePluginConvars()
 	g_cvar[BotReduction] = AutoExecConfig_CreateConVar("sm_bot_quota_reduct", "8", "How many bots to take off max for small maps");
 	g_cvar[BotReductionDec] = AutoExecConfig_CreateConVar("sm_bot_quota_reduct_dec", "12", "How many bots to take off max for small maps");
 	g_cvar[BotDiffMult] = AutoExecConfig_CreateConVar("sm_bot_quota_dmult", "2.15", "Bot Fill = Player Count Difference * x - 1");
-	g_cvar[BoosterQuota] = AutoExecConfig_CreateConVar("sm_booster_bot_quota", "28", "sets the bota bot quota"); 
+	g_cvar[BoosterQuota] = AutoExecConfig_CreateConVar("sm_booster_bot_quota", "28", "sets the bota bot quota");
+	
 	g_cvar[DisableBotsAt] = AutoExecConfig_CreateConVar("sm_disable_bots_at", "8", "sets when disable bots"); 
 	g_cvar[DisableBotsAtDec] = AutoExecConfig_CreateConVar("sm_disable_bots_at_dec", "6", "sets when disable bots sooner on certain maps");
 	g_cvar[DisableBotsAtInc] = AutoExecConfig_CreateConVar("sm_disable_bots_at_inc", "8", "sets when disable bots later on certain maps");
+	g_cvar[DisableBotsTeam] = AutoExecConfig_CreateConVar("sm_disable_bots_at", "5", "sets when team-based disable bots"); 
+	g_cvar[DisableBotsTeamDec] = AutoExecConfig_CreateConVar("sm_disable_bots_at_dec", "4", "sets when team disable bots sooner on certain maps");
+	g_cvar[DisableBotsTeamInc] = AutoExecConfig_CreateConVar("sm_disable_bots_at_inc", "5", "sets when team disable bots later on certain maps");
+	
 	g_cvar[BotOverblance] = AutoExecConfig_CreateConVar("sm_bot_overbalance", "3", "sets team difference allowed with bots enabled"); 
 	g_cvar[RegOverblance] = AutoExecConfig_CreateConVar("sm_reg_overbalance", "1", "sets team difference allowed with bots disabled");
 	g_cvar[turretCountDec] = AutoExecConfig_CreateConVar("sm_bot_turrent", "40", "sets number of turrets to reduce bot counts");

--- a/addons/sourcemod/scripting/nd_bot_feat/modulus_quota.sp
+++ b/addons/sourcemod/scripting/nd_bot_feat/modulus_quota.sp
@@ -77,6 +77,50 @@ int GetSmallMapCount(int totalCount, int specCount, int rQuota)
 	return botAmount;
 }
 
+bool CheckShutOffBots()
+{
+	// Get the current map we're playing
+	char map[32];
+	GetCurrentMap(map, sizeof(map));
+	
+	// Get the empire, consort and total on team count
+	int empireCount = RED_GetTeamCount(TEAM_EMPIRE);
+	int consortCount = RED_GetTeamCount(TEAM_CONSORT);	
+	int totalCount = empireCount + consortCount;
+	
+	// Disable bots sooner if it's a tiny maps
+	if (ND_CustomMapEquals(map, ND_Sandbrick))
+	{
+		// If empire or consort has the min team players, disable bots
+		int teamDisableDec = g_cvar[DisableBotsTeamDec].IntValue;		
+		if (empireCount >= teamDisableDec || consortCount >= teamDisableDec)
+			return true;
+		
+		// Otherwise, if the total on team count is reached, disable bots
+		return totalCount >= g_cvar[DisableBotsAtDec].IntValue;
+	}
+	
+	// Disable bots later on big maps, to compensate for the size
+	else if (ND_StockMapEquals(map, ND_Gate) || ND_StockMapEquals(map, ND_Downtown))
+	{
+		// If empire or consort has the min team players, disable bots
+		int teamDisableInc = g_cvar[DisableBotsTeamInc].IntValue;
+		if (empireCount >= teamDisableInc || consortCount >= teamDisableInc)
+			return true;
+			
+		// Otherwise, if the total on team count is reached, disable bots
+		return totalCount >= g_cvar[DisableBotsAtInc].IntValue;	
+	}
+	
+	// If empire or consort has the min team players, disable bots
+	int teamDisableReg = g_cvar[DisableBotsTeam].IntValue;
+	if (empireCount >= teamDisableReg || consortCount >= teamDisableReg)
+		return true;
+		
+	// Otherwise, if the total on team count is reached, disable bots
+	return g_cvar[DisableBotsAt].IntValue;	
+}
+
 int GetBotShutOffCount()
 {
 	char map[32];

--- a/addons/sourcemod/scripting/nd_bot_feat/modulus_quota.sp
+++ b/addons/sourcemod/scripting/nd_bot_feat/modulus_quota.sp
@@ -86,29 +86,29 @@ bool CheckShutOffBots()
 	// Get the empire, consort and total on team count
 	int empireCount = RED_GetTeamCount(TEAM_EMPIRE);
 	int consortCount = RED_GetTeamCount(TEAM_CONSORT);	
-	int totalCount = empireCount + consortCount;
+	int totalDisable, teamDisable;
 	
 	// Disable bots sooner if it's a tiny maps
 	if (ND_CustomMapEquals(map, ND_Sandbrick))
 	{		
-		// If total count on one or both teams is reached, disable bots
-		bool teamDisableDec = TCDisableBots(empireCount, consortCount, g_cvar[DisableBotsTeamDec].IntValue);
-		return teamDisableDec || totalCount >= g_cvar[DisableBotsAtDec].IntValue;
+		teamDisable = g_cvar[DisableBotsTeamDec].IntValue;
+		totalDisable = g_cvar[DisableBotsAtDec].IntValue;
 	}
 	
 	// Disable bots later on big maps, to compensate for the size
 	else if (ND_StockMapEquals(map, ND_Gate) || ND_StockMapEquals(map, ND_Downtown))
 	{
-		// If total count on one or both teams is reached, disable bots
-		bool teamDisableInc = TCDisableBots(empireCount, consortCount, g_cvar[DisableBotsTeamInc].IntValue);
-		return teamDisableInc || totalCount >= g_cvar[DisableBotsAtInc].IntValue;	
+		teamDisable = g_cvar[DisableBotsTeamInc].IntValue;
+		totalDisable = g_cvar[DisableBotsAtInc].IntValue;	
+	}
+	
+	else
+	{
+		teamDisable = g_cvar[DisableBotsTeam].IntValue;
+		totalDisable = g_cvar[DisableBotsAt].IntValue
 	}
 	
 	// If total count on one or both teams is reached, disable bots
-	bool teamDisableReg = TCDisableBots(empireCount, consortCount, g_cvar[DisableBotsTeam].IntValue);
-	return teamDisableReg || g_cvar[DisableBotsAt].IntValue;	
-}
-
-bool TCDisableBots(int empire, int consort, int threshold){
-	return empire >= threshold || consort >= threshold;
+	bool isTotalDisable = (empireCount + consortCount) >= totalDisable;
+	return isTotalDisable || empireCount >= teamDisable || consortCount >= teamDisable;
 }

--- a/addons/sourcemod/scripting/nd_bot_feat/modulus_quota.sp
+++ b/addons/sourcemod/scripting/nd_bot_feat/modulus_quota.sp
@@ -120,21 +120,3 @@ bool CheckShutOffBots()
 	// Otherwise, if the total on team count is reached, disable bots
 	return g_cvar[DisableBotsAt].IntValue;	
 }
-
-int GetBotShutOffCount()
-{
-	char map[32];
-	GetCurrentMap(map, sizeof(map));
-
-	// Disable bots sooner if it's a tiny/broken map
-	// ND_StockMapEquals(map, ND_Oilfield) || ND_CustomMapEquals(map, ND_Corner)
-	if (ND_CustomMapEquals(map, ND_Sandbrick))
-		return g_cvar[DisableBotsAtDec].IntValue;
-	
-	// Disable bots later if it's a large stock map
-	if (ND_StockMapEquals(map, ND_Gate) || ND_StockMapEquals(map, ND_Downtown))
-		return g_cvar[DisableBotsAtInc].IntValue;
-	
-	/* Otherwise, return the default value */
-	return g_cvar[DisableBotsAt].IntValue;
-}

--- a/addons/sourcemod/scripting/nd_bot_feat/modulus_quota.sp
+++ b/addons/sourcemod/scripting/nd_bot_feat/modulus_quota.sp
@@ -90,33 +90,25 @@ bool CheckShutOffBots()
 	
 	// Disable bots sooner if it's a tiny maps
 	if (ND_CustomMapEquals(map, ND_Sandbrick))
-	{
-		// If empire or consort has the min team players, disable bots
-		int teamDisableDec = g_cvar[DisableBotsTeamDec].IntValue;		
-		if (empireCount >= teamDisableDec || consortCount >= teamDisableDec)
-			return true;
-		
-		// Otherwise, if the total on team count is reached, disable bots
-		return totalCount >= g_cvar[DisableBotsAtDec].IntValue;
+	{		
+		// If total count on one or both teams is reached, disable bots
+		bool teamDisableDec = TCDisableBots(empireCount, consortCount, g_cvar[DisableBotsTeamDec].IntValue);
+		return teamDisableDec || totalCount >= g_cvar[DisableBotsAtDec].IntValue;
 	}
 	
 	// Disable bots later on big maps, to compensate for the size
 	else if (ND_StockMapEquals(map, ND_Gate) || ND_StockMapEquals(map, ND_Downtown))
 	{
-		// If empire or consort has the min team players, disable bots
-		int teamDisableInc = g_cvar[DisableBotsTeamInc].IntValue;
-		if (empireCount >= teamDisableInc || consortCount >= teamDisableInc)
-			return true;
-			
-		// Otherwise, if the total on team count is reached, disable bots
-		return totalCount >= g_cvar[DisableBotsAtInc].IntValue;	
+		// If total count on one or both teams is reached, disable bots
+		bool teamDisableInc = TCDisableBots(empireCount, consortCount, g_cvar[DisableBotsTeamInc].IntValue);
+		return teamDisableInc || totalCount >= g_cvar[DisableBotsAtInc].IntValue;	
 	}
 	
-	// If empire or consort has the min team players, disable bots
-	int teamDisableReg = g_cvar[DisableBotsTeam].IntValue;
-	if (empireCount >= teamDisableReg || consortCount >= teamDisableReg)
-		return true;
-		
-	// Otherwise, if the total on team count is reached, disable bots
-	return g_cvar[DisableBotsAt].IntValue;	
+	// If total count on one or both teams is reached, disable bots
+	bool teamDisableReg = TCDisableBots(empireCount, consortCount, g_cvar[DisableBotsTeam].IntValue);
+	return teamDisableReg || g_cvar[DisableBotsAt].IntValue;	
+}
+
+bool TCDisableBots(int empire, int consort, int threshold){
+	return empire >= threshold || consort >= threshold;
 }

--- a/addons/sourcemod/scripting/nd_bot_features.sp
+++ b/addons/sourcemod/scripting/nd_bot_features.sp
@@ -147,7 +147,7 @@ void checkCount()
 				float timerDuration = 1.5;
 				if (quota >= dynamicSlots && getPositiveOverBalance() >= 2)
 				{
-					quota = getBotFillerQuota(teamCount);
+					quota = getBotFillerQuota(teamCount, false);
 					
 					if (!visibleBoosted)
 						toggleBooster(true);
@@ -227,7 +227,7 @@ void SignalMapChange()
 }
 
 //When teams have two or more less players
-int getBotFillerQuota(int teamCount, bool addSpectators = false)
+int getBotFillerQuota(int teamCount, bool addSpectators)
 {
 	// Set bot count to player count difference * x - 1.
 	// Team count offset required to fill the quota properly.

--- a/addons/sourcemod/scripting/nd_bot_features.sp
+++ b/addons/sourcemod/scripting/nd_bot_features.sp
@@ -130,7 +130,7 @@ void checkCount()
 		int quota = 0;
 	
 		// Team count means the requirement for modulous bot quota
-		if (RED_OnTeamCount() < GetBotShutOffCount())
+		if (CheckShutOffBots())
 			quota += boostBots() ? getBotModulusQuota() : g_cvar[BotCount].IntValue;
 		
 		// The plugin to get the server slot is available
@@ -181,7 +181,7 @@ void InitializeServerBots()
 	
 	// Team count means the requirement for modulous bot quota
 	// Decide which type of modulous quota we're using (boosted or regular)
-	if (RED_OnTeamCount() < GetBotShutOffCount())
+	if (CheckShutOffBots())
 		quota = boostBots() ? getBotModulusQuota() : g_cvar[BotCount].IntValue;
 	
 	ServerCommand("bot_quota %d", quota);

--- a/addons/sourcemod/scripting/nd_bot_features.sp
+++ b/addons/sourcemod/scripting/nd_bot_features.sp
@@ -142,7 +142,7 @@ void checkCount()
 			{
 				int dynamicSlots = GetDynamicSlotCount() - 2; // Get the bot count to fill empty team slots
 				int teamCount = OnTeamCount(); // Team count, with bot filter
-				quota = getBotFillerQuota(teamCount);
+				quota = getBotFillerQuota(teamCount, true);
 				
 				float timerDuration = 1.5;
 				if (quota >= dynamicSlots && getPositiveOverBalance() >= 2)


### PR DESCRIPTION
- Fix a regression with the bot filler quota not calculating the right number.

- Remove default argument from the bot filler quota function to prevent future regressions.

- Add ConVars to control the shut of bot modulus quota based on individual team counts.

- Adjust bot modulus quota to shut-off during most scenarios, where it could benefit the stacked team.