### PR TITLE
Improve Commander Chair Blocks

### DIFF
--- a/addons/sourcemod/scripting/nd_commander_chair.sp
+++ b/addons/sourcemod/scripting/nd_commander_chair.sp
@@ -68,7 +68,7 @@ public void OnPluginStart()
 public void ND_OnPreRoundStart()
 {
 	// If we have enough players, set commander selection time to min; otherwise, set it to max.
-	int selectTime = ChairBlockThresholdReached() ? cvarSelectMin.IntValue : cvarSelectMax.IntValue;
+	int selectTime = RStartThresholdReached() ? cvarSelectMin.IntValue : cvarSelectMax.IntValue;
 	ServerCommand("sm_cvar nd_commander_election_time %d", selectTime);
 }
 

--- a/addons/sourcemod/scripting/nd_commander_chair.sp
+++ b/addons/sourcemod/scripting/nd_commander_chair.sp
@@ -142,12 +142,12 @@ public Action ND_OnCommanderEnterChair(int client, int team)
 {	
 	if (!BothTeamsHadCommander())
 	{
-		if (!ChairWaitRStartElapsed && ChairBlockThresholdReached())
+		if (!ChairWaitRStartElapsed && RStartThresholdReached())
 		{
 			PrintMessageTI1(client, "Wait Enter Chair", cvarMaxRStart.IntValue);
 			return Plugin_Handled;
 		}
-		else if (!ChairWaitPromoteElapsed[team-2] && ChairWaitThresholdReached())
+		else if (!ChairWaitPromoteElapsed[team-2] && WaitPromotionThresholdReached())
 		{
 			PrintMessageTI1(client, "Wait Enter Chair", cvarMaxPromote.IntValue);
 			return Plugin_Handled;
@@ -161,13 +161,13 @@ bool TotalPlayerTresholdReached() {
 	return ND_GetClientCount() >= cvarMinTotal.IntValue;
 }
 
-bool ChairBlockThresholdReached()
+bool RStartThresholdReached()
 {
 	bool teamThreshold = RED_OnTeamCount() >= cvarMinTeam.IntValue;
 	return teamThreshold || TotalPlayerTresholdReached();
 }
 
-bool ChairWaitThresholdReached()
+bool WaitPromotionThresholdReached()
 {
 	int min = cvarMinEach.IntValue;
 	int empire = RED_GetTeamCount(TEAM_EMPIRE);


### PR DESCRIPTION
- Separate round start and after promotion chair wait thresholds for increased accuracy.

- Wait for 3 players on each team after promotion, instead of 8 players total on any team.