### PR TITLE
Improve Bot Features

### DIFF
--- a/addons/sourcemod/scripting/nd_bot_features.sp
+++ b/addons/sourcemod/scripting/nd_bot_features.sp
@@ -146,7 +146,7 @@ void checkCount()
 				quota = getBotFillerQuota(teamCount, posOverBalance);
 				
 				float timerDuration = 1.5;
-				if (quota >= dynamicSlots && posOverBalance >= 2 && !visibleBoosted)
+				if (quota >= dynamicSlots && posOverBalance >= 2)
 					toggleBooster(true);	
 	
 				else if (visibleBoosted)
@@ -187,20 +187,18 @@ void InitializeServerBots()
 
 bool boostBots()
 {
-	if (g_cvar[BoostBots].BoolValue && TDS_AVAILABLE())
-	{
-		if (!visibleBoosted)
-			toggleBooster(true);
-		
-		return true;
-	}
-
-	return false;
+	bool boost = g_cvar[BoostBots].BoolValue;
+	toggleBooster(boost);
+	return boost;
 }
 
 //Turn 32 slots on or off for bot quota
 void toggleBooster(bool state)
 {	
+	// Exit function if the state is not changing
+	if (visibleBoosted == state)
+		return;
+	
 	visibleBoosted = state;
 	
 	if (TDS_AVAILABLE())
@@ -216,9 +214,7 @@ void toggleBooster(bool state)
 //Disable the 32 slots (if activate) when the map changes
 void SignalMapChange()
 {
-	if (visibleBoosted)
-		toggleBooster(false);	
-
+	toggleBooster(false);
 	ServerCommand("bot_quota 0");
 	ServerCommand("mp_limitteams 1");
 }

--- a/addons/sourcemod/scripting/nd_bot_features.sp
+++ b/addons/sourcemod/scripting/nd_bot_features.sp
@@ -146,10 +146,12 @@ void checkCount()
 				quota = getBotFillerQuota(teamCount, posOverBalance);
 				
 				float timerDuration = 1.5;
-				if (quota >= dynamicSlots && posOverBalance >= 2 && !visibleBoosted)
+				if (quota >= dynamicSlots && posOverBalance >= 2)
 				{
-					quota = getBotFillerQuota(teamCount, posOverBalance, true);					
-					toggleBooster(true);					
+					quota = getBotFillerQuota(teamCount, posOverBalance, true);
+					
+					if (!visibleBoosted)
+						toggleBooster(true);					
 				}
 	
 				else if (visibleBoosted)

--- a/addons/sourcemod/scripting/nd_bot_features.sp
+++ b/addons/sourcemod/scripting/nd_bot_features.sp
@@ -143,12 +143,12 @@ void checkCount()
 				int posOverBalance = getPositiveOverBalance(); // The player difference between the two teams				
 				int dynamicSlots = GetDynamicSlotCount() - 2; // Get the bot count to fill empty team slots
 				int teamCount = OnTeamCount(); // Team count, with bot filter
-				quota = getBotFillerQuota(teamCount, posOverBalance, false);
+				quota = getBotFillerQuota(teamCount, posOverBalance);
 				
 				float timerDuration = 1.5;
 				if (quota >= dynamicSlots && posOverBalance >= 2)
 				{
-					quota = getBotFillerQuota(teamCount, posOverBalance, true);
+					quota = getBotFillerQuota(teamCount, posOverBalance);
 					
 					if (!visibleBoosted)
 						toggleBooster(true);
@@ -229,7 +229,7 @@ void SignalMapChange()
 }
 
 //When teams have two or more less players
-int getBotFillerQuota(int teamCount, int plyDiff, bool substractUnassigned)
+int getBotFillerQuota(int teamCount, int plyDiff)
 {
 	// Set bot count to player count difference * x - 1.
 	// Team count offset required to fill the quota properly.
@@ -237,10 +237,6 @@ int getBotFillerQuota(int teamCount, int plyDiff, bool substractUnassigned)
 	
 	// Add the spectator count becuase it takes away one bot by default
 	total += ValidTeamCount(TEAM_SPEC);
-	
-	// Subtract unassigned if necessary to allow players to connect
-	if (substractUnassigned && total >= 29)
-		total -= ValidTeamCount(TEAM_UNASSIGNED);
 	
 	// Set a ceiling of 29 to be returned
 	return total > 29 ? 29 : total;

--- a/addons/sourcemod/scripting/nd_bot_features.sp
+++ b/addons/sourcemod/scripting/nd_bot_features.sp
@@ -143,7 +143,7 @@ void checkCount()
 				int posOverBalance = getPositiveOverBalance(); // The player difference between the two teams				
 				int dynamicSlots = GetDynamicSlotCount() - 2; // Get the bot count to fill empty team slots
 				int teamCount = OnTeamCount(); // Team count, with bot filter
-				quota = getBotFillerQuota(teamCount, posOverBalance);
+				quota = getBotFillerQuota(teamCount, posOverBalance, false);
 				
 				float timerDuration = 1.5;
 				if (quota >= dynamicSlots && posOverBalance >= 2)
@@ -229,7 +229,7 @@ void SignalMapChange()
 }
 
 //When teams have two or more less players
-int getBotFillerQuota(int teamCount, int plyDiff, bool substractUnassigned = false)
+int getBotFillerQuota(int teamCount, int plyDiff, bool substractUnassigned)
 {
 	// Set bot count to player count difference * x - 1.
 	// Team count offset required to fill the quota properly.

--- a/addons/sourcemod/scripting/nd_bot_features.sp
+++ b/addons/sourcemod/scripting/nd_bot_features.sp
@@ -151,7 +151,7 @@ void checkCount()
 					quota = getBotFillerQuota(teamCount, posOverBalance, true);
 					
 					if (!visibleBoosted)
-						toggleBooster(true);					
+						toggleBooster(true);
 				}
 	
 				else if (visibleBoosted)

--- a/addons/sourcemod/scripting/nd_bot_features.sp
+++ b/addons/sourcemod/scripting/nd_bot_features.sp
@@ -146,13 +146,8 @@ void checkCount()
 				quota = getBotFillerQuota(teamCount, posOverBalance);
 				
 				float timerDuration = 1.5;
-				if (quota >= dynamicSlots && posOverBalance >= 2)
-				{
-					quota = getBotFillerQuota(teamCount, posOverBalance);
-					
-					if (!visibleBoosted)
-						toggleBooster(true);
-				}
+				if (quota >= dynamicSlots && posOverBalance >= 2 && !visibleBoosted)
+					toggleBooster(true);	
 	
 				else if (visibleBoosted)
 				{


### PR DESCRIPTION
- Always add spectator counts to bot quota. Use clamp instead to keep connecting slots open.

- Don't change the booster mode when the state is the same. Simplify the code.