### PR TITLE
Improve Bot Features

### DIFF
--- a/addons/sourcemod/scripting/nd_bot_feat/commands.sp
+++ b/addons/sourcemod/scripting/nd_bot_feat/commands.sp
@@ -35,7 +35,7 @@ public Action CMD_GetBotPow(int client, int args)
 	float phys = g_cvar[BotDiffMult].FloatValue;	
 	for (int pNum = 1; pNum <= 5; pNum++)
 	{
-		int value = RoundPowToNearest(float(num), exp);
+		int value = RoundPowToNearest(float(num), phys);
 		PrintToConsole(client, "Round: %d ^ %.2f = %d", pNum, phys, value);
 	}
 	
@@ -47,7 +47,7 @@ public Action CMD_GetBotPow(int client, int args)
 	float skill = g_cvar[BotSkillMult].FloatValue;
 	for (int sNum = 1; sNum <= 5; sNum++)
 	{
-		int value = RoundPowToNearest(float(num), exp);
+		int value = RoundPowToNearest(float(num), skill);
 		PrintToConsole(client, "Round: %d% ^ %.2f = %d", sNum*100, skill, value);
 	}
 

--- a/addons/sourcemod/scripting/nd_bot_feat/commands.sp
+++ b/addons/sourcemod/scripting/nd_bot_feat/commands.sp
@@ -35,7 +35,7 @@ public Action CMD_GetBotPow(int client, int args)
 	float phys = g_cvar[BotDiffMult].FloatValue;	
 	for (int pNum = 1; pNum <= 5; pNum++)
 	{
-		int value = RoundPowToNearest(float(num), phys);
+		int value = RoundPowToNearest(float(pNum), phys);
 		PrintToConsole(client, "Round: %d ^ %.2f = %d", pNum, phys, value);
 	}
 	
@@ -47,7 +47,7 @@ public Action CMD_GetBotPow(int client, int args)
 	float skill = g_cvar[BotSkillMult].FloatValue;
 	for (int sNum = 1; sNum <= 5; sNum++)
 	{
-		int value = RoundPowToNearest(float(num), skill);
+		int value = RoundPowToNearest(float(sNum), skill);
 		PrintToConsole(client, "Round: %d% ^ %.2f = %d", sNum*100, skill, value);
 	}
 

--- a/addons/sourcemod/scripting/nd_bot_feat/commands.sp
+++ b/addons/sourcemod/scripting/nd_bot_feat/commands.sp
@@ -30,12 +30,25 @@ public Action CMD_DisableBots(int client, int args)
 
 public Action CMD_GetBotPow(int client, int args)
 {
-	float exp = g_cvar[BotDiffMult].FloatValue;
-	
-	for (int num = 1; num <= 5; num++)
+	// Print the physical player difference from 1-5 for bot counts
+	PrintToConsole(client, "--> Physical Player Difference <--");	
+	float phys = g_cvar[BotDiffMult].FloatValue;	
+	for (int pNum = 1; pNum <= 5; pNum++)
 	{
 		int value = RoundPowToNearest(float(num), exp);
-		PrintToConsole(client, "Round: %d ^ %.2f = %d", num, exp, value);
+		PrintToConsole(client, "Round: %d ^ %.2f = %d", pNum, phys, value);
+	}
+	
+	// Print a spacer in console, before starting the next section
+	PrintToConsole(client, "");
+	
+	// Print the skill percent difference from 1-5 for bot counts
+	PrintToConsole(client, "--> Skill Percent Difference <--");	
+	float skill = g_cvar[BotSkillMult].FloatValue;
+	for (int sNum = 1; sNum <= 5; sNum++)
+	{
+		int value = RoundPowToNearest(float(num), exp);
+		PrintToConsole(client, "Round: %d% ^ %.2f = %d", sNum*100, skill, value);
 	}
 
 	return Plugin_Handled;

--- a/addons/sourcemod/scripting/nd_bot_feat/convars.sp
+++ b/addons/sourcemod/scripting/nd_bot_feat/convars.sp
@@ -7,6 +7,7 @@ enum convars
 	 ConVar:BotReduction,
 	 ConVar:BotReductionDec,
 	 ConVar:BotDiffMult,
+	 ConVar:BotSkillMult,
 	 ConVar:BoosterQuota,
 	 
 	 ConVar:DisableBotsAt,
@@ -35,6 +36,7 @@ void CreatePluginConvars()
 	g_cvar[BotReduction] = AutoExecConfig_CreateConVar("sm_bot_quota_reduct", "8", "How many bots to take off max for small maps");
 	g_cvar[BotReductionDec] = AutoExecConfig_CreateConVar("sm_bot_quota_reduct_dec", "12", "How many bots to take off max for small maps");
 	g_cvar[BotDiffMult] = AutoExecConfig_CreateConVar("sm_bot_quota_dmult", "2.15", "Bot Fill = Player Count Difference * x - 1");
+	g_cvar[BotSkillMult] =	AutoExecConfig_CreateConVar("sm_bot_quota_smult", "1.2", "Multiply teamdiff by x to increase bots");
 	g_cvar[BoosterQuota] = AutoExecConfig_CreateConVar("sm_booster_bot_quota", "28", "sets the bota bot quota");
 	
 	g_cvar[DisableBotsAt] = AutoExecConfig_CreateConVar("sm_disable_bots_at", "8", "sets when disable bots"); 

--- a/addons/sourcemod/scripting/nd_bot_feat/convars.sp
+++ b/addons/sourcemod/scripting/nd_bot_feat/convars.sp
@@ -35,8 +35,8 @@ void CreatePluginConvars()
 	g_cvar[BotCount] = AutoExecConfig_CreateConVar("sm_botcount", "20", "sets the regular bot count.");
 	g_cvar[BotReduction] = AutoExecConfig_CreateConVar("sm_bot_quota_reduct", "8", "How many bots to take off max for small maps");
 	g_cvar[BotReductionDec] = AutoExecConfig_CreateConVar("sm_bot_quota_reduct_dec", "12", "How many bots to take off max for small maps");
-	g_cvar[BotDiffMult] = AutoExecConfig_CreateConVar("sm_bot_quota_dmult", "2.15", "Bot Fill = Player Count Difference * x - 1");
-	g_cvar[BotSkillMult] =	AutoExecConfig_CreateConVar("sm_bot_quota_smult", "1.2", "Multiply teamdiff by x to increase bots");
+	g_cvar[BotDiffMult] = AutoExecConfig_CreateConVar("sm_bot_quota_dmult", "1.65", "Physical player Difference ^ x");
+	g_cvar[BotSkillMult] =	AutoExecConfig_CreateConVar("sm_bot_quota_smult", "1.75", "Skill difference ^ x");
 	g_cvar[BoosterQuota] = AutoExecConfig_CreateConVar("sm_booster_bot_quota", "28", "sets the bota bot quota");
 	
 	g_cvar[DisableBotsAt] = AutoExecConfig_CreateConVar("sm_disable_bots_at", "8", "sets when disable bots"); 

--- a/addons/sourcemod/scripting/nd_bot_features.sp
+++ b/addons/sourcemod/scripting/nd_bot_features.sp
@@ -198,8 +198,11 @@ float getTeamDiffMult()
 	if (getLSTeam(teamDiff) != getTeamLessPlayers() || average < 0.0)
 		return 0.0;
 		
-	// Otherwise, team / average. Convert teamDiff to positive number if required.
-	return teamDiff < 0 ? teamDiff * -1.0 / average : teamDiff / average;
+	// Cauclate team difference mult with teamDiff / average. Convert teamDiff to positive number if required.
+	float difference = teamDiff < 0 ? teamDiff * -1.0 / average : teamDiff / average;
+	
+	// Multiply the difference multipler to increase the bot count.
+	return difference * g_cvar[BotSkillMult].FloatValue;
 }
 
 int getLSTeam(float td) {

--- a/addons/sourcemod/scripting/nd_bot_features.sp
+++ b/addons/sourcemod/scripting/nd_bot_features.sp
@@ -172,7 +172,7 @@ int getBotFillerQuota(int plyDiff)
 	
 	// Set bot count to player count difference * x - 1 or skill difference * x - 1
 	int physical = teamCount + RoundPowToNearest(float(plyDiff), g_cvar[BotDiffMult].FloatValue);
-	int skill = teamCount + RoundPowToNearest(getTeamDiffMult(), g_cvar[BotDiffMult].FloatValue);
+	int skill = teamCount + RoundPowToNearest(getTeamDiffMult(), g_cvar[BotSkillMult].FloatValue);
 	
 	// Set a ceiling to be returned, leave two connecting slots
 	int maxQuota = g_cvar[BoosterQuota].IntValue;
@@ -198,12 +198,8 @@ float getTeamDiffMult()
 	if (getLSTeam(teamDiff) != getTeamLessPlayers() || average < 0.0)
 		return 0.0;
 		
-	// Cauclate team difference mult with teamDiff / average. Convert teamDiff to positive number if required.
-	float difference = teamDiff < 0 ? teamDiff * -1.0 / average : teamDiff / average;
-	
-	// Multiply the difference multipler to increase the bot count.
-	return difference * g_cvar[BotSkillMult].FloatValue;
-}
+	// Otherwise, team / average. Convert teamDiff to positive number if required.
+	return teamDiff < 0 ? teamDiff * -1.0 / average : teamDiff / average;
 
 int getLSTeam(float td) {
 	return td > 0 ? TEAM_CONSORT : TEAM_EMPIRE;

--- a/addons/sourcemod/scripting/nd_bot_features.sp
+++ b/addons/sourcemod/scripting/nd_bot_features.sp
@@ -200,6 +200,7 @@ float getTeamDiffMult()
 		
 	// Otherwise, team / average. Convert teamDiff to positive number if required.
 	return teamDiff < 0 ? teamDiff * -1.0 / average : teamDiff / average;
+}
 
 int getLSTeam(float td) {
 	return td > 0 ? TEAM_CONSORT : TEAM_EMPIRE;


### PR DESCRIPTION
- Use a separate exponent for skill percent difference, to increase bot counts more aggressively.

- Update the sm_botpow command to reflect the new skill percent difference multiplier.