### PR TITLE
Improve Bot Features

### DIFF
--- a/addons/sourcemod/scripting/include/nd_stocks.inc
+++ b/addons/sourcemod/scripting/include/nd_stocks.inc
@@ -254,12 +254,11 @@ stock int getRandomTeam()
 // Return -1 if both teams have the same count
 stock int getTeamLessPlayers()
 {
-	int teamCount[2];
-	teamCount[CONSORT_AIDX] = ValidTeamCount(TEAM_CONSORT);
-	teamCount[EMPIRE_AIDX] = ValidTeamCount(TEAM_EMPIRE);
+	int consortCount = ValidTeamCount(TEAM_CONSORT);
+	int empireCount = ValidTeamCount(TEAM_EMPIRE);	
 
-	if (teamCount[CONSORT_AIDX] == teamCount[EMPIRE_AIDX])
+	if (consortCount == empireCount)
 		return TEAM_NONE;
 	
-	return teamCount[CONSORT_AIDX] < teamCount[EMPIRE_AIDX] ? TEAM_CONSORT : TEAM_EMPIRE;
+	return consortCount < empireCount ? TEAM_CONSORT : TEAM_EMPIRE;
 }

--- a/addons/sourcemod/scripting/nd_bot_feat/commands.sp
+++ b/addons/sourcemod/scripting/nd_bot_feat/commands.sp
@@ -44,19 +44,19 @@ public Action CMD_GetBotPow(int client, int args)
 	
 	// Print the skill percent difference from 100% to 500% for uneven bot counts
 	PrintToConsole(client, "--> Uneven Skill Percent Difference <--");
-	WriteConsoleSkillValues(g_cvar[BotSkillMult].FloatValue, 100, 1, 5);
+	WriteConsoleSkillValues(client, g_cvar[BotSkillMult].FloatValue, 100, 1, 5);
 
 	// Print a spacer in console, before starting the next section
 	PrintToConsole(client, "");
 	
 	// Print the skill percent difference from 150% to 400% for even bot counts
 	PrintToConsole(client, "--> Even Skill Percent Difference <--");
-	WriteConsoleSkillValues(g_cvar[BotEvenSkillMult].FloatValue, 50, 3, 8);
+	WriteConsoleSkillValues(client, g_cvar[BotEvenSkillMult].FloatValue, 50, 3, 8);
 
 	return Plugin_Handled;
 }
 
-WriteConsoleSkillValues(float mult, int interval, int start, int finish)
+void WriteConsoleSkillValues(int client, float mult, int interval, int start, int finish)
 {
 	for (int sNum = start; sNum <= finish; sNum++)
 	{

--- a/addons/sourcemod/scripting/nd_bot_feat/commands.sp
+++ b/addons/sourcemod/scripting/nd_bot_feat/commands.sp
@@ -42,14 +42,25 @@ public Action CMD_GetBotPow(int client, int args)
 	// Print a spacer in console, before starting the next section
 	PrintToConsole(client, "");
 	
-	// Print the skill percent difference from 1-5 for bot counts
-	PrintToConsole(client, "--> Skill Percent Difference <--");	
-	float skill = g_cvar[BotSkillMult].FloatValue;
-	for (int sNum = 1; sNum <= 5; sNum++)
-	{
-		int value = RoundPowToNearest(float(sNum), skill);
-		PrintToConsole(client, "Round: %d% ^ %.2f = %d", sNum*100, skill, value);
-	}
+	// Print the skill percent difference from 100% to 500% for uneven bot counts
+	PrintToConsole(client, "--> Uneven Skill Percent Difference <--");
+	WriteConsoleSkillValues(g_cvar[BotSkillMult].FloatValue, 100, 1, 5);
+
+	// Print a spacer in console, before starting the next section
+	PrintToConsole(client, "");
+	
+	// Print the skill percent difference from 150% to 400% for even bot counts
+	PrintToConsole(client, "--> Even Skill Percent Difference <--");
+	WriteConsoleSkillValues(g_cvar[BotEvenSkillMult].FloatValue, 50, 3, 8);
 
 	return Plugin_Handled;
+}
+
+WriteConsoleSkillValues(float mult, int interval, int start, int finish)
+{
+	for (int sNum = start; sNum <= finish; sNum++)
+	{
+		int value = RoundPowToNearest(float(sNum), mult);
+		PrintToConsole(client, "Round: %d% ^ %.2f = %d", sNum*interval, mult, value);
+	}
 }

--- a/addons/sourcemod/scripting/nd_bot_feat/convars.sp
+++ b/addons/sourcemod/scripting/nd_bot_feat/convars.sp
@@ -10,6 +10,9 @@ enum convars
 	 ConVar:BotSkillMult,
 	 ConVar:BoosterQuota,
 	 
+	 ConVar:BotEvenPlysEnable,
+	 ConVar:BotEvenSkillMult,
+	 
 	 ConVar:DisableBotsAt,
 	 ConVar:DisableBotsAtDec,
 	 ConVar:DisableBotsAtInc,
@@ -35,9 +38,12 @@ void CreatePluginConvars()
 	g_cvar[BotCount] = AutoExecConfig_CreateConVar("sm_botcount", "20", "sets the regular bot count.");
 	g_cvar[BotReduction] = AutoExecConfig_CreateConVar("sm_bot_quota_reduct", "8", "How many bots to take off max for small maps");
 	g_cvar[BotReductionDec] = AutoExecConfig_CreateConVar("sm_bot_quota_reduct_dec", "12", "How many bots to take off max for small maps");
-	g_cvar[BotDiffMult] = AutoExecConfig_CreateConVar("sm_bot_quota_dmult", "1.65", "Physical player Difference ^ x");
-	g_cvar[BotSkillMult] =	AutoExecConfig_CreateConVar("sm_bot_quota_smult", "1.75", "Skill difference ^ x");
 	g_cvar[BoosterQuota] = AutoExecConfig_CreateConVar("sm_booster_bot_quota", "28", "sets the bota bot quota");
+	
+	g_cvar[BotEvenPlysEnable] = AutoExecConfig_CreateConVar("sm_bot_even_threshold", "150", "Sets min skill diff for bots with even player counts");
+	g_cvar[BotEvenSkillMult] = AutoExecConfig_CreateConVar("sm_bot_even_smult", "1.4", "Even skill difference ^ x");
+	g_cvar[BotSkillMult] =	AutoExecConfig_CreateConVar("sm_bot_quota_smult", "1.75", "Uneven skill difference ^ x");
+	g_cvar[BotDiffMult] = AutoExecConfig_CreateConVar("sm_bot_quota_dmult", "1.65", "Player difference ^ x");
 	
 	g_cvar[DisableBotsAt] = AutoExecConfig_CreateConVar("sm_disable_bots_at", "8", "sets when disable bots"); 
 	g_cvar[DisableBotsAtDec] = AutoExecConfig_CreateConVar("sm_disable_bots_at_dec", "6", "sets when disable bots sooner on certain maps");

--- a/addons/sourcemod/scripting/nd_bot_features.sp
+++ b/addons/sourcemod/scripting/nd_bot_features.sp
@@ -197,15 +197,15 @@ int getBotFillerQuota(int plyDiff, float teamDiffMult)
 int getBotEvenQuota(float teamDiffMult)
 {
 	// Get the team count offset to fill the bot quota and set bot count to skill difference ^ x
-	int teamCount = GetOnTeamCount(ValidTeamCount(TEAM_SPEC));
-	int skillCount = RoundPowToNearest(teamDiffMult, g_cvar[BotEvenSkillMult].FloatValue);
+	int specCount = ValidTeamCount(TEAM_SPEC);
+	int skill = GetOnTeamCount(specCount) + RoundPowToNearest(teamDiffMult, g_cvar[BotEvenSkillMult].FloatValue);
 	
 	// Set a ceiling to be returned, leave two connecting slots
-	return Math_Max(teamCount + skillCount, GetMaxBotCount(specCount));
+	return Math_Max(skill, GetMaxBotCount(specCount));
 }
 
 int GetMaxBotCount(int specCount) {
-	return maxBots = g_cvar[BoosterQuota].IntValue - ValidTeamCount(TEAM_UNASSIGNED) - specCount;
+	return g_cvar[BoosterQuota].IntValue - ValidTeamCount(TEAM_UNASSIGNED) - specCount;
 }
 
 int GetOnTeamCount(int specCount) {
@@ -288,7 +288,7 @@ void SwitchBotsToTeam(int team)
 		if (IsClientConnected(bot) && IsClientInGame(bot) && IsFakeClient(bot) && GetClientTeam(bot) != team)
 		{
 			ChangeClientTeam(bot, TEAM_SPEC);
-			ChangeClientTeam(bot, teamLessPlys);
+			ChangeClientTeam(bot, team);
 		}
 	}
 }


### PR DESCRIPTION
- Add support for bot additions during even player counts, when the skill difference is 150%+.

- Update the sm_botpow command to support bot additions numbers during even player counts.

- Make the getTeamLessPlayers() stock int function more readable, by removing unnecessary arrays,

- Refactor some bot features base code to make it more readable, abstract and faster.