### PR TITLE
Spawn bots after switching team

### DIFF
--- a/addons/sourcemod/scripting/include/nd_transport_eng.inc
+++ b/addons/sourcemod/scripting/include/nd_transport_eng.inc
@@ -27,3 +27,9 @@ stock int ND_GetTransportCount(int team)
 	
 	return gates[team];
 }
+
+define NRSL_AVAILABLE() (GetFeatureStatus(FeatureType_Native, "ND_RefreshSpawnLocs") == FeatureStatus_Available)
+native void ND_RefreshSpawnLocs(float delay);
+
+define NFSP_AVAILABLE() (GetFeatureStatus(FeatureType_Native, "ND_ForceSpawnPlayer") == FeatureStatus_Available)
+native void ND_ForceSpawnPlayer(int client, float delay);

--- a/addons/sourcemod/scripting/include/nd_transport_eng.inc
+++ b/addons/sourcemod/scripting/include/nd_transport_eng.inc
@@ -28,8 +28,8 @@ stock int ND_GetTransportCount(int team)
 	return gates[team];
 }
 
-define NRSL_AVAILABLE() (GetFeatureStatus(FeatureType_Native, "ND_RefreshSpawnLocs") == FeatureStatus_Available)
+#define NRSL_AVAILABLE() (GetFeatureStatus(FeatureType_Native, "ND_RefreshSpawnLocs") == FeatureStatus_Available)
 native void ND_RefreshSpawnLocs(float delay);
 
-define NFSP_AVAILABLE() (GetFeatureStatus(FeatureType_Native, "ND_ForceSpawnPlayer") == FeatureStatus_Available)
+#define NFSP_AVAILABLE() (GetFeatureStatus(FeatureType_Native, "ND_ForceSpawnPlayer") == FeatureStatus_Available)
 native void ND_ForceSpawnPlayer(int client, float delay);

--- a/addons/sourcemod/scripting/nd_bot_features.sp
+++ b/addons/sourcemod/scripting/nd_bot_features.sp
@@ -17,6 +17,7 @@
 
 #pragma newdecls required
 #include <nd_team_eng>
+#include <nd_transport_eng>
 #include <nd_redstone>
 #include <nd_rounds>
 #include <nd_maps>
@@ -292,12 +293,22 @@ public Action TIMER_CheckAndSwitchEven(Handle timer)
 
 void SwitchBotsToTeam(int team)
 {
+	bool switchedBot = false;
+	
 	for (int bot = 1; bot < MaxClients; bot++)
 	{
 		if (IsClientConnected(bot) && IsClientInGame(bot) && IsFakeClient(bot) && GetClientTeam(bot) != team)
 		{
 			ChangeClientTeam(bot, TEAM_SPEC);
 			ChangeClientTeam(bot, team);
+			
+			// Mark switched bot, and force them to spawn after 8s
+			switchedBot = true;
+			ND_ForceSpawnPlayer(bot, 8.0);
 		}
 	}
+	
+	// Refresh the spawn locations, so bots spawn in a valid location
+	if (switchedBot)
+		ND_RefreshSpawnLocs(6.5);
 }

--- a/addons/sourcemod/scripting/nd_transport_engine.sp
+++ b/addons/sourcemod/scripting/nd_transport_engine.sp
@@ -131,7 +131,7 @@ void ForcePlayerSpawn(int client)
 		SetEntPropVector(client, Prop_Send, "m_vecSelectedSpawnArea", gateVecs[team-2]);
 		
 		// Set the player class to a random value, if they're not a bot
-		if (!IsFakeClient(client)		
+		if (!IsFakeClient(client))		
 			FakeClientCommand(client, "joinclass %d 0", GetRandomInt(0,3));
 			
 		// Indicate ready to play, to force the spawn spawn to happen

--- a/addons/sourcemod/scripting/nd_transport_engine.sp
+++ b/addons/sourcemod/scripting/nd_transport_engine.sp
@@ -91,13 +91,22 @@ public int Native_GetTeamTGCount(Handle plugin, int numParams) {
 }
 
 public int Native_RefreshSpawnLocs(Handle plugin, int numParams) {
+	float delay = GetNativeCell(1);
+	CreateTimer(delay, RefreshSpawnLocs, _, TIMER_FLAG_NO_MAPCHANGE);
+}
+
+public Action RefreshSpawnLocs(Handle timer)
+{
 	RefreshTransports();
+	return Plugin_Handled;
 }
 
 public int Native_ForceSpawnPlayer(Handle plugin, int numParams)
 {
-	float delay = GetNativeCell(1);
-	CreateTimer(delay, ForceSpawn, GetClientUserId(GetNativeCell(1)), TIMER_FLAG_NO_MAPCHANGE);
+	int client = GetNativeCell(1);
+	float delay = GetNativeCell(2);
+	
+	CreateTimer(delay, ForceSpawn, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE);
 }
 
 public Action ForceSpawn(Handle timer, any:Userid)

--- a/addons/sourcemod/scripting/nd_transport_engine.sp
+++ b/addons/sourcemod/scripting/nd_transport_engine.sp
@@ -17,6 +17,7 @@ public Plugin myinfo =
 #include "updater/standard.sp"
 
 int gateCount[TEAM_COUNT] = { 0, ... };
+float gateVecs[2][3];
 
 public void ND_OnRoundStarted() {
 	resetVars();
@@ -67,6 +68,7 @@ void RefreshTransports()
 	while ((loopEntity = FindEntityByClassname(loopEntity, STRUCT_TRANSPORT)) != INVALID_ENT_REFERENCE)
 	{
 		int team = GetEntProp(loopEntity, Prop_Send, "m_iTeamNum");
+		GetEntPropVector(loopEntity, Prop_Send, "m_vecOrigin", gateVecs[team-2]);		
 		newGates[team]++;
 	}
 	
@@ -78,10 +80,52 @@ void RefreshTransports()
 public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
 {
 	CreateNative("ND_GetTeamTGCache", Native_GetTeamTGCount);
+	CreateNative("ND_RefreshSpawnLocs", Native_RefreshSpawnLocs);
+	CreateNative("ND_ForceSpawnPlayer", Native_ForceSpawnPlayer);
 	return APLRes_Success;
 }
 
 public int Native_GetTeamTGCount(Handle plugin, int numParams) {
 	// Return the transport gate count for the inputted team
 	return gateCount[GetNativeCell(1)];
+}
+
+public int Native_RefreshSpawnLocs(Handle plugin, int numParams) {
+	RefreshTransports();
+}
+
+public int Native_ForceSpawnPlayer(Handle plugin, int numParams)
+{
+	float delay = GetNativeCell(1);
+	CreateTimer(delay, ForceSpawn, GetClientUserId(GetNativeCell(1)), TIMER_FLAG_NO_MAPCHANGE);
+}
+
+public Action ForceSpawn(Handle timer, any:Userid)
+{
+	int client = GetClientOfUserId(Userid);	
+	if (client && IsClientInGame(client))
+	{
+		ForcePlayerSpawn(client);
+		return Plugin_Handled;
+	}	
+	
+	//CreateTimer(0.5, ForceSpawn, Userid, TIMER_FLAG_NO_MAPCHANGE);
+	return Plugin_Handled;
+}
+
+void ForcePlayerSpawn(int client) 
+{
+	int team = GetClientTeam(client);
+	if (team > 1) 
+	{
+		// Set the location of the spawn area from the cached vector coordinates
+		SetEntPropVector(client, Prop_Send, "m_vecSelectedSpawnArea", gateVecs[team-2]);
+		
+		// Set the player class to a random value, if they're not a bot
+		if (!IsFakeClient(client)		
+			FakeClientCommand(client, "joinclass %d 0", GetRandomInt(0,3));
+			
+		// Indicate ready to play, to force the spawn spawn to happen
+		FakeClientCommand(client, "readytoplay");	
+	}
 }


### PR DESCRIPTION
- Add force player spawn support to nd_transport_engine.

- Add refresh spawn location support to nd_transport_engine.

- Forcefully spawn bots 8s after switch them, to fix spawn bugs.