### PR TITLE
Improve damage multipliers

### DIFF
--- a/addons/sourcemod/scripting/include/nd_print.inc
+++ b/addons/sourcemod/scripting/include/nd_print.inc
@@ -52,6 +52,17 @@ stock void PrintMessageAllEx(const char[] phrase)
 	}
 }
 
+stock void PrintMessageTeam(int team, const char[] phrase) 
+{
+	for (int client = 1; client <= MaxClients; client++) 
+	{
+		if (IsClientInGame(client) && GetClientTeam(client) == team)
+		{	
+			PrintMessage(client, phrase);
+		}
+	}
+}
+
 stock void PrintMessageAllTB(const char[] phrase) 
 {
 	for (int client = 1; client <= MaxClients; client++) 

--- a/addons/sourcemod/scripting/include/nd_print.inc
+++ b/addons/sourcemod/scripting/include/nd_print.inc
@@ -118,6 +118,17 @@ stock void PrintMessageTeamTI1(int team, char[] transString, int intArg)
 	}
 }
 
+stock void PrintConsoleTeamTI1(int team, char[] transString, int intArg)
+{
+	for (int client = 1; client <= MaxClients; client++) 
+	{
+		if (IsClientInGame(client) && GetClientTeam(client) == team)
+		{
+			PrintToConsole(client, "%s %t!", PREFIX, transString, intArg);
+		}
+	}
+}
+
 // This function is an alais, to symbolize printing translations instead of strings
 stock void PrintMessageTeamTT1(int team, char[] transString, char[] transArg) {
 	PrintMessageTeamTS1(team, transString, transArg);

--- a/addons/sourcemod/scripting/nd_damage/convars.sp
+++ b/addons/sourcemod/scripting/nd_damage/convars.sp
@@ -217,7 +217,7 @@ void CreateGLConVars()
 		"Percentage of normal damage GLs deal to after Infantry Boost 2",
 		"Percentage of normal damage GLs deal to after Infantry Boost 3"
 	};
-	char convarDef[multGL][] = { 	"120", "110", "125", "110"
+	char convarDef[multGL][] = { 	"120", "110", "125", "110",
 					"103", "106", "109" };
 	
 	for (int convar = 0; convar < view_as<int>(multGL); convar++) {

--- a/addons/sourcemod/scripting/nd_damage/convars.sp
+++ b/addons/sourcemod/scripting/nd_damage/convars.sp
@@ -41,7 +41,10 @@ enum multGL
 	gl_bunker_mult = 0,
 	gl_assembler_mult,
 	gl_transport_mult,
-	gl_ft_turret_mult
+	gl_ft_turret_mult,
+	gl_ib1_base_mult,
+	gl_ib2_base_mult,
+	gl_ib3_base_mult
 }
 
 enum multOther
@@ -191,19 +194,31 @@ void CreateGLConVars()
 	
 	// GLs (Grenade Launchers)
 	char convarName[multGL][] = {		
+		// GL Structure Damage
 		"sm_mult_bunker_gl",
 		"sm_mult_assembler_gl",
 		"sm_mult_transport_gl",
-		"sm_mult_ft_turret_gl"
+		"sm_mult_ft_turret_gl",
+		
+		// GL Base Damage
+		"sm_mult_baseIB1_gl",
+		"sm_mult_baseIB2_gl",
+		"sm_mult_baseIB3_gl"
 	};
 	char convarDesc[multGL][] = {		
-		// GLs (Grenade Launchers)
+		// GL Structure Damage
 		"Percentage of normal damage GLs deal to the bunker",
 		"Percentage of normal damage GLs deal to assemblers",
 		"Percentage of normal damage GLs deal to transport gates",
-		"Percentage of normal damage GLs deal to ft/sonic turrets"	
+		"Percentage of normal damage GLs deal to ft/sonic turrets",
+		
+		// GL Base Damage
+		"Percentage of normal damage GLs deal to after Infantry Boost 1",
+		"Percentage of normal damage GLs deal to after Infantry Boost 2",
+		"Percentage of normal damage GLs deal to after Infantry Boost 3"
 	};
-	char convarDef[multGL][] = { "120", "110", "125", "110" };
+	char convarDef[multGL][] = { 	"120", "110", "125", "110"
+					"103", "106", "109" };
 	
 	for (int convar = 0; convar < view_as<int>(multGL); convar++) {
 		gCvar_GL[convar] = AutoExecConfig_CreateConVar(convarName[convar], convarDef[convar], convarDesc[convar]);	

--- a/addons/sourcemod/scripting/nd_damage/damage_events.sp
+++ b/addons/sourcemod/scripting/nd_damage/damage_events.sp
@@ -36,10 +36,20 @@ public Action ND_OnBarrierDamaged(int victim, int &attacker, int &inflictor, flo
 		
 		case WEAPON_EXPLO_DT:
 		{
-			if (InflictorIsArtillery(iClass(inflictor)))
+			char className[64];
+			GetEntityClassname(inflictor, className, sizeof(className));
+			
+			if (InflictorIsArtillery(className))
 			{
 				float multiplier = Artillery_StructureReinMult(attacker);
 				damage *= multiplier;
+				return Plugin_Changed;
+			}
+			
+			else if (InflictorIsGL(className))
+			{
+				float multIB = GL_InfantryBoostMult(attacker);
+				damage *= multIB;
 				return Plugin_Changed;
 			}
 		}
@@ -66,10 +76,19 @@ public Action ND_OnWallDamaged(int victim, int &attacker, int &inflictor, float 
 		
 		case WEAPON_EXPLO_DT:
 		{
-			if (InflictorIsArtillery(iClass(inflictor)))
+			char className[64];
+			GetEntityClassname(inflictor, className, sizeof(className));
+			
+			if (InflictorIsArtillery(className))
 			{
 				float multiplier = Artillery_StructureReinMult(attacker);
 				damage *= multiplier;
+				return Plugin_Changed;
+			}
+			else if (InflictorIsGL(className))
+			{
+				float multIB = GL_InfantryBoostMult(attacker);
+				damage *= multIB;
 				return Plugin_Changed;
 			}
 		}
@@ -97,10 +116,19 @@ public Action ND_OnSupplyStationDamaged(int victim, int &attacker, int &inflicto
 		
 		case WEAPON_EXPLO_DT:
 		{
-			if (InflictorIsArtillery(iClass(inflictor)))
+			char className[64];
+			GetEntityClassname(inflictor, className, sizeof(className));
+			
+			if (InflictorIsArtillery(className))
 			{
 				float multiplier = Artillery_StructureReinMult(attacker);
 				damage *= multiplier;
+				return Plugin_Changed;
+			}
+			else if (InflictorIsGL(className))
+			{
+				float multIB = GL_InfantryBoostMult(attacker);
+				damage *= multIB;
 				return Plugin_Changed;
 			}
 		}
@@ -135,10 +163,19 @@ public Action ND_OnRocketTurretDamaged(int victim, int &attacker, int &inflictor
 		
 		case WEAPON_EXPLO_DT:
 		{
-			if (InflictorIsArtillery(iClass(inflictor)))
+			char className[64];
+			GetEntityClassname(inflictor, className, sizeof(className));
+			
+			if (InflictorIsArtillery(className))
 			{
 				float multiplier = Artillery_StructureReinMult(attacker);
 				damage *= multiplier;
+				return Plugin_Changed;
+			}
+			else if (InflictorIsGL(className))
+			{
+				float multIB = GL_InfantryBoostMult(attacker);
+				damage *= multIB;
 				return Plugin_Changed;
 			}
 		}
@@ -173,10 +210,19 @@ public Action ND_OnMGTurretDamaged(int victim, int &attacker, int &inflictor, fl
 		
 		case WEAPON_EXPLO_DT:
 		{
-			if (InflictorIsArtillery(iClass(inflictor)))
+			char className[64];
+			GetEntityClassname(inflictor, className, sizeof(className));
+			
+			if (InflictorIsArtillery(className))
 			{
 				float multiplier = Artillery_StructureReinMult(attacker);
 				damage *= multiplier;
+				return Plugin_Changed;
+			}
+			else if (InflictorIsGL(className))
+			{
+				float multIB = GL_InfantryBoostMult(attacker);
+				damage *= multIB;
 				return Plugin_Changed;
 			}
 		}
@@ -214,6 +260,12 @@ public Action ND_OnRadarDamaged(int victim, int &attacker, int &inflictor, float
 			{
 				float multiplier = Artillery_StructureReinMult(attacker);
 				damage *= multiplier;
+				return Plugin_Changed;
+			}
+			else if (InflictorIsGL(className))
+			{
+				float multIB = GL_InfantryBoostMult(attacker);
+				damage *= multIB;
 				return Plugin_Changed;
 			}
 		}
@@ -263,6 +315,12 @@ public Action ND_OnArmouryDamaged(int victim, int &attacker, int &inflictor, flo
 				damage *= multiplier;
 				return Plugin_Changed;
 			}
+			else if (InflictorIsGL(className))
+			{
+				float multIB = GL_InfantryBoostMult(attacker);
+				damage *= multIB;
+				return Plugin_Changed;
+			}
 		}
 		
 		case WEAPON_FLAME_DT:
@@ -308,6 +366,12 @@ public Action ND_OnPowerPlantDamaged(int victim, int &attacker, int &inflictor, 
 			{
 				float multiplier = Artillery_StructureReinMult(attacker);
 				damage *= multiplier;
+				return Plugin_Changed;
+			}
+			else if (InflictorIsGL(className))
+			{
+				float multIB = GL_InfantryBoostMult(attacker);
+				damage *= multIB;
 				return Plugin_Changed;
 			}
 		}
@@ -370,6 +434,9 @@ public Action ND_OnFlamerTurretDamaged(int victim, int &attacker, int &inflictor
 			}
 			else if (InflictorIsGL(className))
 			{
+				float multIB = GL_InfantryBoostMult(attacker);
+				damage *= multIB;
+				
 				float multiplier = gFloat_GL[gl_ft_turret_mult];
 				damage *= multiplier;
 				return Plugin_Changed;
@@ -421,6 +488,12 @@ public Action ND_OnArtilleryDamaged(int victim, int &attacker, int &inflictor, f
 			{
 				float multiplier = Artillery_StructureReinMult(attacker);
 				damage *= multiplier;
+				return Plugin_Changed;
+			}
+			else if (InflictorIsGL(className))
+			{
+				float multIB = GL_InfantryBoostMult(attacker);
+				damage *= multIB;
 				return Plugin_Changed;
 			}
 		}
@@ -483,6 +556,9 @@ public Action ND_OnTransportDamaged(int victim, int &attacker, int &inflictor, f
 			}
 			else if (InflictorIsGL(className))
 			{
+				float multIB = GL_InfantryBoostMult(attacker);
+				damage *= multIB;
+				
 				float multiplier = gFloat_GL[gl_transport_mult];
 				damage *= multiplier;
 				return Plugin_Changed;
@@ -549,6 +625,9 @@ public Action ND_OnAssemblerDamaged(int victim, int &attacker, int &inflictor, f
 			}
 			else if (InflictorIsGL(className))
 			{				
+				float multIB = GL_InfantryBoostMult(attacker);
+				damage *= multIB;
+				
 				float multiplier = gFloat_GL[gl_assembler_mult];
 				damage *= multiplier; 
 				return Plugin_Changed;
@@ -627,6 +706,9 @@ public Action ND_OnBunkerDamaged(int victim, int &attacker, int &inflictor, floa
 			}			
 			else if (InflictorIsGL(className))
 			{
+				float multIB = GL_InfantryBoostMult(attacker);
+				damage *= multIB;
+				
 				float multiplier = gFloat_GL[gl_bunker_mult];
 				damage *= multiplier;
 				return Plugin_Changed;
@@ -678,13 +760,27 @@ bool InflictorIsNX300(int &inflictor) {
 
 float BBQ_InfantryBoostMult(int &attacker)
 {
-	float mult = 1.0;	
+	float mult = 1.0;
 	
 	switch(GetAttackerTeamIB(attacker))
 	{
 		case 1: mult = gFloat_Other[nx300_ib1_base_mult];
 		case 2: mult = gFloat_Other[nx300_ib2_base_mult];
 		case 3: mult = gFloat_Other[nx300_ib3_base_mult];	
+	}
+	
+	return mult;
+}
+
+float GL_InfantryBoostMult(int &attacker)
+{
+	float mult = 1.0;
+	
+	switch(GetAttackerTeamIB(attacker))
+	{
+		case 1: mult = gFloat_Other[gl_ib1_base_mult];
+		case 2: mult = gFloat_Other[gl_ib2_base_mult];
+		case 3: mult = gFloat_Other[gl_ib3_base_mult];	
 	}
 	
 	return mult;

--- a/addons/sourcemod/scripting/nd_damage_mult.sp
+++ b/addons/sourcemod/scripting/nd_damage_mult.sp
@@ -49,7 +49,7 @@ public void OnInfantryBoostResearched(int team, int level)
 	InfantryBoostLevel[team-2] = level;
 	
 	// Notify team the bbq damage has increased at each level
-	float percentBBQ = getInfantryBoostMult(level);
+	float percentBBQ = getInfantryBoostMultBBQ(level);
 	int increaseBBQ = RoundFloat((percentBBQ - 1.0) * 100.0);
 	PrintMessageTeamTI1(team, "BBQ Damage Increase", increaseBBQ);
 	

--- a/addons/sourcemod/scripting/nd_damage_mult.sp
+++ b/addons/sourcemod/scripting/nd_damage_mult.sp
@@ -49,12 +49,17 @@ public void OnInfantryBoostResearched(int team, int level)
 	InfantryBoostLevel[team-2] = level;
 	
 	// Notify team the bbq damage has increased at each level
-	float percent = getInfantryBoostMult(level);
-	int speed = RoundFloat((percent - 1.0) * 100.0);
-	PrintMessageTeamTI1(team, "BBQ Damage Increase", speed);
+	float percentBBQ = getInfantryBoostMult(level);
+	int increaseBBQ = RoundFloat((percentBBQ - 1.0) * 100.0);
+	PrintMessageTeamTI1(team, "BBQ Damage Increase", increaseBBQ);
+	
+	// Notify team the gl damage has increased at each level
+	float percentGL = getInfantryBoostMultGL(level);
+	int increaseGL = RoundFloat((percentGL - 1.0) * 100.0);
+	PrintMessageTeamTI1(team, "GL Damage Increase", increaseGL);
 }
 
-float getInfantryBoostMult(int level)
+float getInfantryBoostMultBBQ(int level)
 {
 	float mult = 1.0;
 	
@@ -62,7 +67,21 @@ float getInfantryBoostMult(int level)
 	{
 		case 1: mult = gFloat_Other[nx300_ib1_base_mult];
 		case 2: mult = gFloat_Other[nx300_ib2_base_mult];
-		case 3: mult = gFloat_Other[nx300_ib3_base_mult];	
+		case 3: mult = gFloat_Other[nx300_ib3_base_mult];
+	}
+	
+	return mult;
+}
+
+float getInfantryBoostMultGL(int level)
+{
+	float mult = 1.0;
+	
+	switch(level)
+	{
+		case 1: mult = gFloat_Other[gl_ib1_base_mult];
+		case 2: mult = gFloat_Other[gl_ib2_base_mult];
+		case 3: mult = gFloat_Other[gl_ib3_base_mult];
 	}
 	
 	return mult;

--- a/addons/sourcemod/scripting/nd_damage_mult.sp
+++ b/addons/sourcemod/scripting/nd_damage_mult.sp
@@ -48,15 +48,18 @@ public void OnInfantryBoostResearched(int team, int level)
 {
 	InfantryBoostLevel[team-2] = level;
 	
-	// Notify team the bbq damage has increased at each level
+	// Notify team bbq & gl damage value are displayed in console
+	PrintMessageTeam(team, "Weapon Damage Console");
+	
+	// Print team bbq damage increases at each level to console
 	float percentBBQ = getInfantryBoostMultBBQ(level);
 	int increaseBBQ = RoundFloat((percentBBQ - 1.0) * 100.0);
-	PrintMessageTeamTI1(team, "BBQ Damage Increase", increaseBBQ);
-	
-	// Notify team the gl damage has increased at each level
+	PrintConsoleTeamTI1(team, "BBQ Damage Increase", increaseBBQ);
+
+	// Print team gl damage increases at each level to console
 	float percentGL = getInfantryBoostMultGL(level);
 	int increaseGL = RoundFloat((percentGL - 1.0) * 100.0);
-	PrintMessageTeamTI1(team, "GL Damage Increase", increaseGL);
+	PrintConsoleTeamTI1(team, "GL Damage Increase", increaseGL);
 }
 
 float getInfantryBoostMultBBQ(int level)

--- a/updater/nd_damage_mult/translations/nd_damage_mult.phrases.txt
+++ b/updater/nd_damage_mult/translations/nd_damage_mult.phrases.txt
@@ -1,5 +1,10 @@
 "Phrases"
 {
+	"Weapon Damage Console"
+	{
+		"en"		"See console for weapon damage increases"
+	}
+	
 	"BBQ Damage Increase"
 	{
 		"#format"	"{1:i}"

--- a/updater/nd_damage_mult/translations/nd_damage_mult.phrases.txt
+++ b/updater/nd_damage_mult/translations/nd_damage_mult.phrases.txt
@@ -6,6 +6,12 @@
 		"en"		"BBQ weapon damage increased by {1}%"
 	}
 	
+	"GL Damage Increase"
+	{
+		"#format"	"{1:i}"
+		"en"		"Grenadier weapon damage increased by {1}%"
+	}
+	
 	"Artillery Damage Decrease"
 	{
 		"#format"	"{1:i}"


### PR DESCRIPTION
- Add GL damage increases of 3%, 6% and 9% for Infantry boost.

- Move weapon damage increase values to console (to save space).

- Display GL damage increases in console. Add new stock functions.