### PR TITLE
Expanded on the resource capture tips

### DIFF
--- a/updater/nd_player_tips/translations/nd_player_tips.phrases.txt
+++ b/updater/nd_player_tips/translations/nd_player_tips.phrases.txt
@@ -30,9 +30,21 @@
 		"en"		"You cannot capture resources while in stealth mode"
 	}
 	
-	"Resource Timer Reset"
+	"Prime Resource Timer Reset"
 	{
-		// To alert players who interupt the capture timer with the use of special abilities (Exo suit Lockdown, or Stealth) 
-		"en"		"Leaving the resource or using special abilities resets the capture timer! Stay on the point to help your team"
+		// To alert players who interupt the capture timer of the Primary resource with the use of special abilities (Exo suit Lockdown, or Stealth) 
+		"en"		"Leaving the Primary resource or using special abilities resets the capture timer! Stay on the point to help your team"
+	}
+	
+	"Other Resource Timer Reset"
+	{
+		// To alert players who interupt the capture timer of other resources with the use of special abilities (Exo suit Lockdown, or Stealth) 
+		"en"		"Using special abilities stops the timer as long as you stay close! Stay on the point to help your team"
+	}
+	
+	"Leaving Resource Incomplete"
+	{
+		// To alert players who leave the resource with out capturing them 
+		"en"		"Leaving an uncaptured resource before it is fully captured will gradually return it to a neutral state. "
 	}
 }


### PR DESCRIPTION
Split the Primary resource alert from the others, as it resets completely and the others gradually reduce. 

And tried to split the leaving a non prime resource and special function, as if you leave the timer falls back to 0 gradually, but if you special function it stays still.