### PR TITLE
Add new triggered player tips

### DIFF
--- a/updater/nd_player_tips/translations/nd_player_tips.phrases.txt
+++ b/updater/nd_player_tips/translations/nd_player_tips.phrases.txt
@@ -39,26 +39,29 @@
 	"Lost Prime"
 	{
 		// To alert players that they have just lost Prime 
-		"en"		"You have just lost the Primary resource point, this is valuable to your team. Try to re-capture ASAP."
+		"en"		"You have just lost the Primary resource point, this is valuable to your team. Try to re-capture ASAP"
 	}
 	
 	"Bunker Health Warning"
 	{
 		// To alert players when their teams Command Bunkers health reaches x (maybe 75%) and suggest they spawn as Engie ASAP
-		"en"		"Your Comand Bunker is down to xx%% health, consider spawning as Support Engineer next time, to repair your Bunker. "
+		"#format"	"{1:i}"
+		"en"		"Your Comand Bunker is down to {1}%% health, consider spawning as Support Engineer next time, to repair your Bunker"
 	}	
 	
 	"Extreme Bunker Health Warning"
 	{
 		// To alert players when their teams Command Bunkers health reaches x (maybe 50%) and strongly suggest they spawn as Engie ASAP
-		"en"		"Warning Bunker is down to xx%% health, it is stronly recomended you change to Support Engineer to repair your Bunker ASAP. "
+		"#format"	"{1:i}"
+		"en"		"Warning Bunker is down to {1}%% health, it is stronly recomended you change to Support Engineer to repair your Bunker ASAP"
 	}
 	
 	"Average team health low"
 	{
 		// To warn when average health of players on your team is low (not sure about the numbers of this, needs some thinking and this may need some form of running average ...) 
 		// Would need a check about number of Medics already in the field (to suspend notice if there are 1 or 2 already in the team) 
-		"en"		"The average health of players on your team is xx%%, consider spawning as Support Medic, to heal them in the field. "
+		"#format"	"{1:i}"
+		"en"		"The average health of players on your team is {1}%%, consider spawning as Support Medic, to heal them in the field"
 	}
 	
 	"name"

--- a/updater/nd_player_tips/translations/nd_player_tips.phrases.txt
+++ b/updater/nd_player_tips/translations/nd_player_tips.phrases.txt
@@ -35,4 +35,36 @@
 		// To alert players who interupt the capture timer with the use of special abilities (Exo suit Lockdown, or Stealth) 
 		"en"		"Leaving the resource or using special abilities resets the capture timer! Stay on the point to help your team"
 	}
+	
+	"Lost Prime"
+	{
+		// To alert players that they have just lost Prime 
+		"en"		"You have just lost the Primary resource point, this is valuable to your team. Try to re-capture ASAP."
+	}
+	
+	"Bunker Health Warning"
+	{
+		// To alert players when their teams Command Bunkers health reaches x (maybe 75%) and suggest they spawn as Engie ASAP
+		"en"		"Your Comand Bunker is down to xx%% health, consider spawning as Support Engineer next time, to repair your Bunker. "
+	}	
+	
+	"Extreme Bunker Health Warning"
+	{
+		// To alert players when their teams Command Bunkers health reaches x (maybe 50%) and strongly suggest they spawn as Engie ASAP
+		"en"		"Warning Bunker is down to xx%% health, it is stronly recomended you change to Support Engineer to repair your Bunker ASAP. "
+	}
+	
+	"Average team health low"
+	{
+		// To warn when average health of players on your team is low (not sure about the numbers of this, needs some thinking and this may need some form of running average ...) 
+		// Would need a check about number of Medics already in the field (to suspend notice if there are 1 or 2 already in the team) 
+		"en"		"The average health of players on your team is xx%%, consider spawning as Support Medic, to heal them in the field. "
+	}
+	
+	"name"
+	{
+		// note 
+		"en"		"text "
+	}
+	
 }


### PR DESCRIPTION
As discussed on steam IM, 

I have added warning that Prime has been lost, a Bunker health warning, an extreme bunker health warning, 

And an average team health warning, but this one is ... needs some thought.