### PR TITLE
Improve Resource Spawner

### DIFF
--- a/addons/sourcemod/scripting/nd_res_spawn/alpha.sp
+++ b/addons/sourcemod/scripting/nd_res_spawn/alpha.sp
@@ -59,7 +59,7 @@ void AdjustTertiarySpawns()
 		RemoveTertiaryPoint("tertiary_4", "tertiary_area4");
 		
 		RemoveTertiaryPoint("tertiary_tunnel", "tertiary_tunnel_area");		
-		SpawnTertiaryPoint({1690.0, 4970.0, -1390.0});
+		SpawnTertiaryPoint({1690.0, 4970.0, -1390.0}, true);
 	}
 	
 	else if (ND_StockMapEquals(map_name, ND_Oasis))
@@ -74,7 +74,7 @@ void AdjustTertiarySpawns()
 		
 		// Move the sand tertiary over more
 		//RemoveTertiaryPoint("tertiary_sand", "tertiary_area");
-		//SpawnTertiaryPoint({6700.0, 6800.0, 45.0});
+		//SpawnTertiaryPoint({6700.0, 6800.0, 45.0}, true);
 	}
 	
 	else if (ND_CustomMapEquals(map_name, ND_Mars))
@@ -98,8 +98,8 @@ void CheckTertiarySpawns()
 	{
 		if (RED_OnTeamCount() >= cvarDowntownTertiarySpawns.IntValue)
 		{
-			SpawnTertiaryPoint({-2160.0, 6320.0, -3840.0});
-			SpawnTertiaryPoint({753.0, 1468.0, -3764.0});
+			SpawnTertiaryPoint({-2160.0, 6320.0, -3840.0}, true);
+			SpawnTertiaryPoint({753.0, 1468.0, -3764.0}, true);
 			tertsSpawned[SECOND_TIER] = true;
 		}
 	}
@@ -108,8 +108,8 @@ void CheckTertiarySpawns()
 	{
 		if (RED_OnTeamCount() >= cvarDowntownTertiarySpawns.IntValue)
 		{
-			SpawnTertiaryPoint({2224.0, -784.0, -3200.0});
-			SpawnTertiaryPoint({753.0, 1468.0, -3764.0});
+			SpawnTertiaryPoint({2224.0, -784.0, -3200.0}, true);
+			SpawnTertiaryPoint({753.0, 1468.0, -3764.0}, true);
 			tertsSpawned[SECOND_TIER] = true;
 		}
 	}
@@ -118,8 +118,8 @@ void CheckTertiarySpawns()
 	{
 		if (RED_OnTeamCount() >= cvarRoadworkTertiarySpawns.IntValue)
 		{
-			SpawnTertiaryPoint({3456.0, -5760.0, 7.0});
-			SpawnTertiaryPoint({-6912.0, -2648.0, -118.0});
+			SpawnTertiaryPoint({3456.0, -5760.0, 7.0}, true);
+			SpawnTertiaryPoint({-6912.0, -2648.0, -118.0}, true);
 			tertsSpawned[SECOND_TIER] = true;
 		}
 	}
@@ -128,8 +128,8 @@ void CheckTertiarySpawns()
 	{
 		if (RED_OnTeamCount() >= cvarMarsTertiarySpawns.IntValue)
 		{
-			SpawnTertiaryPoint({-556.0, 4408.0, 28.0});
-			SpawnTertiaryPoint({540.0, 3836.0, 28.0});
+			SpawnTertiaryPoint({-556.0, 4408.0, 28.0}, true);
+			SpawnTertiaryPoint({540.0, 3836.0, 28.0}, true);
 			tertsSpawned[SECOND_TIER] = true;
 		}
 	}
@@ -141,15 +141,15 @@ void CheckTertiarySpawns()
 		{
 			if (!tertsSpawned[FIRST_TIER])
 			{
-				SpawnTertiaryPoint({4052.0, 7008.0, -300.0});
-				SpawnTertiaryPoint({-3720.0, -8716.0, -500.0});
+				SpawnTertiaryPoint({4052.0, 7008.0, -300.0}, true);
+				SpawnTertiaryPoint({-3720.0, -8716.0, -500.0}, true);
 				tertsSpawned[FIRST_TIER] = true;
 			}
 			
 			if (teamCount >= cvarRockTertiarySpawns[SECOND_TIER].IntValue)
 			{
-				SpawnTertiaryPoint({5648.0, -3264.0, -496.0});
-				SpawnTertiaryPoint({-3932.0, 2964.0, -496.0});
+				SpawnTertiaryPoint({5648.0, -3264.0, -496.0}, true);
+				SpawnTertiaryPoint({-3932.0, 2964.0, -496.0}, true);
 				tertsSpawned[SECOND_TIER] = true;
 			}
 		}
@@ -162,15 +162,15 @@ void CheckTertiarySpawns()
 		{
 			if (!tertsSpawned[FIRST_TIER])
 			{				
-				SpawnTertiaryPoint({3691.0, 4118.0, -1056.0});
-				SpawnTertiaryPoint({-4221.0, -3844.0, -951.0});
+				SpawnTertiaryPoint({3691.0, 4118.0, -1056.0}, true);
+				SpawnTertiaryPoint({-4221.0, -3844.0, -951.0}, true);
 				tertsSpawned[FIRST_TIER] = true;
 			}
 			
 			if (teamCount >= cvarOilfeildTertiarySpawns[SECOND_TIER].IntValue)
 			{
-				SpawnTertiaryPoint({-6654.0, -4276.0, -904.0});
-				SpawnTertiaryPoint({6642.0, 4530.0, -996.0});
+				SpawnTertiaryPoint({-6654.0, -4276.0, -904.0}, true);
+				SpawnTertiaryPoint({6642.0, 4530.0, -996.0}, true);
 				tertsSpawned[SECOND_TIER] = true;
 			}
 		}
@@ -180,8 +180,8 @@ void CheckTertiarySpawns()
 	{
 		if (RED_OnTeamCount() >= cvarNuclearTertiarySpawns.IntValue)
 		{
-			SpawnTertiaryPoint({7867.0, 3467.0, 21.0});
-			SpawnTertiaryPoint({312.0, 2635.0, -88.0});
+			SpawnTertiaryPoint({7867.0, 3467.0, 21.0}, true);
+			SpawnTertiaryPoint({312.0, 2635.0, -88.0}, true);
 			tertsSpawned[SECOND_TIER] = true;
 		}
 	}
@@ -194,16 +194,16 @@ void CheckTertiarySpawns()
 			if (!tertsSpawned[FIRST_TIER])
 			{
 				// Respawn coutyard and near secondary resources
-				SpawnTertiaryPoint({-5028.0, -2906.0, -1396.0});
-				SpawnTertiaryPoint({-1550.0, 2764.0, -1200.0});
+				SpawnTertiaryPoint({-5028.0, -2906.0, -1396.0}, true);
+				SpawnTertiaryPoint({-1550.0, 2764.0, -1200.0}, true);
 				tertsSpawned[FIRST_TIER] = true;
 			}
 			
 			if (teamCount >= cvarClocktowerTertiarySpawns[SECOND_TIER].IntValue)
 			{
 				// Respawn tunnel resources			
-				SpawnTertiaryPoint({-1674.0, 1201.0, -1848.0});
-				SpawnTertiaryPoint({-2564.0, 282.0, -1672.0});
+				SpawnTertiaryPoint({-1674.0, 1201.0, -1848.0}, true);
+				SpawnTertiaryPoint({-2564.0, 282.0, -1672.0}, true);
 				tertsSpawned[SECOND_TIER] = true;
 			}
 		}		
@@ -214,8 +214,8 @@ void CheckTertiarySpawns()
 		if (RED_OnTeamCount() >= cvarOasisTertiarySpawns.IntValue)
 		{
 			// (Re)spawn tertaries near the secondaries
-			SpawnTertiaryPoint({-4702.0, 1176.0, -224.0});
-			SpawnTertiaryPoint({5600.0, 1500.0, -390.0});
+			SpawnTertiaryPoint({-4702.0, 1176.0, -224.0}, true);
+			SpawnTertiaryPoint({5600.0, 1500.0, -390.0}, true);
 			tertsSpawned[FIRST_TIER] = true;
 		}
 	}
@@ -225,8 +225,8 @@ void CheckTertiarySpawns()
 		if (RED_OnTeamCount() >= cvarCoastTertiarySpawns.IntValue)
 		{
 			// (Re)spawn tertaries near the secondaries			
-			SpawnTertiaryPoint({700.0, 7164.0, 40.0});
-			SpawnTertiaryPoint({2500.0, -528.0, 54.0});
+			SpawnTertiaryPoint({700.0, 7164.0, 40.0}, true);
+			SpawnTertiaryPoint({2500.0, -528.0, 54.0}, true);
 			tertsSpawned[FIRST_TIER] = true;
 		}
 	}

--- a/addons/sourcemod/scripting/nd_res_spawn/commands.sp
+++ b/addons/sourcemod/scripting/nd_res_spawn/commands.sp
@@ -9,13 +9,13 @@ RegAdminSpawnCmds()
 public Action CMD_SpawnSilo(int client, int args)
 {
 	// In middle map
-	SpawnTertiaryPoint({-3375.0, 1050.0, 2.0});
-	SpawnTertiaryPoint({-36.0, -2000.0, 5.0});
+	SpawnTertiaryPoint({-3375.0, 1050.0, 2.0}, true);
+	SpawnTertiaryPoint({-36.0, -2000.0, 5.0}, true);
 	tertsSpawned[FIRST_TIER] = true;
 	
 	// Near base
-	SpawnTertiaryPoint({-5402.0, -3859.0, 74.0});
-	SpawnTertiaryPoint({2340.0, 2558.0, 10.0});
+	SpawnTertiaryPoint({-5402.0, -3859.0, 74.0}, true);
+	SpawnTertiaryPoint({2340.0, 2558.0, 10.0}, true);
 	tertsSpawned[SECOND_TIER] = true;
 	
 	return Plugin_Handled;
@@ -23,8 +23,8 @@ public Action CMD_SpawnSilo(int client, int args)
 
 public Action CMD_SpawnCorner(int client, int args)
 {
-	SpawnTertiaryPoint({-3485.0, 11688.0, 5.0});
-	SpawnTertiaryPoint({-1947.0, -1942.0, 7.0});
+	SpawnTertiaryPoint({-3485.0, 11688.0, 5.0}, true);
+	SpawnTertiaryPoint({-1947.0, -1942.0, 7.0}, true);
 	tertsSpawned[SECOND_TIER] = true;
 
 	return Plugin_Handled;
@@ -32,8 +32,8 @@ public Action CMD_SpawnCorner(int client, int args)
 
 public Action CMD_SpawnDowntown(int client, int args)
 {
-	SpawnTertiaryPoint({2385.0, -5582.0, -3190.0});
-	SpawnTertiaryPoint({-2668.0, -3169.0, -2829.0});
+	SpawnTertiaryPoint({2385.0, -5582.0, -3190.0}, true);
+	SpawnTertiaryPoint({-2668.0, -3169.0, -2829.0}, true);
 	tertsSpawned[SECOND_TIER] = true;
 
 	return Plugin_Handled;
@@ -41,8 +41,8 @@ public Action CMD_SpawnDowntown(int client, int args)
 
 public Action CMD_SpawnHydro(int client, int args)
 {
-	SpawnTertiaryPoint({2132.0, 2559.0, 18.0});
-	SpawnTertiaryPoint({-5199.0, -3461.0, 191.0});
+	SpawnTertiaryPoint({2132.0, 2559.0, 18.0}, true);
+	SpawnTertiaryPoint({-5199.0, -3461.0, 191.0}, true);
 	tertsSpawned[SECOND_TIER] = true;
 
 	return Plugin_Handled;

--- a/addons/sourcemod/scripting/nd_resource_spawner.sp
+++ b/addons/sourcemod/scripting/nd_resource_spawner.sp
@@ -44,6 +44,7 @@ ConVar cvarCornerTertiarySpawns;
 ConVar cvarNuclearTertiarySpawns;
 ConVar cvarRoadworkTertiarySpawns;
 ConVar cvarSiloTertiarySpawns;
+ConVar cvarDowntownTertiarySpawns;
 ConVar cvarGateTertiarySpawns[2];
 ConVar cvarRockTertiarySpawns[2];
 ConVar cvarOilfeildTertiarySpawns[2];
@@ -109,6 +110,7 @@ void CreateMapConvars()
 	cvarCornerTertiarySpawns = AutoExecConfig_CreateConVar("sm_tertiary_corner", "20", "Sets number of players to spawn extra tertaries on corner.");
 	cvarNuclearTertiarySpawns = AutoExecConfig_CreateConVar("sm_tertiary_nuclear", "14", "Sets number of players to spawn extra tertaries on nuclear.");
 	cvarRoadworkTertiarySpawns = AutoExecConfig_CreateConVar("sm_tertiary_roadwork", "16", "Sets number of players to spawn extra tertaries on roadwork.");
+	cvarDowntownTertiarySpawns = AutoExecConfig_CreateConVar("sm_tertiary_downtown", "28", "Sets number of players to spawn extra tertaries on downtown and downtown_dyn.");
 	cvarSiloTertiarySpawns = AutoExecConfig_CreateConVar("sm_tertiary_silo1", "14", "Sets number of players to spawn extra tertaries on silo.");
 	cvarGateTertiarySpawns[FIRST_TIER] = AutoExecConfig_CreateConVar("sm_tertiary_gate1", "16", "Sets number of players to spawn extra tertaries on gate.");
 	cvarGateTertiarySpawns[SECOND_TIER] = AutoExecConfig_CreateConVar("sm_tertiary_gate2", "22", "Sets number of players to spawn extra tertaries on gate.");

--- a/addons/sourcemod/scripting/nd_resource_spawner.sp
+++ b/addons/sourcemod/scripting/nd_resource_spawner.sp
@@ -366,7 +366,7 @@ public void SpawnResourcePoint( const char[] type, const char[] model, int rt, i
 	
 	// If prime is depleted, also deplete the tertiary resource point
 	if (ND_PrimeDepleted())
-		SetEntProp(rt, Prop_Data "m_iCurrentResources", 0);
+		SetEntProp(rt, Prop_Send, "m_iCurrentResources", 0);
        
 	SetEntProp(trigger, Prop_Send, "m_nSolidType", 2);
  

--- a/addons/sourcemod/scripting/nd_resource_spawner.sp
+++ b/addons/sourcemod/scripting/nd_resource_spawner.sp
@@ -363,6 +363,10 @@ public void SpawnResourcePoint( const char[] type, const char[] model, int rt, i
 	SetEntPropFloat(trigger, Prop_Data, "m_flCapTime", 5.0);
 	SetEntProp(trigger, Prop_Data, "m_iButtonsToCap", 0);
 	SetEntProp(trigger, Prop_Data, "m_iNumPlayersToCap", 1);
+	
+	// If prime is depleted, also deplete the tertiary resource point
+	if (ND_PrimeDepleted())
+		SetEntProp(rt, Prop_Data "m_iCurrentResources", 0);
        
 	SetEntProp(trigger, Prop_Send, "m_nSolidType", 2);
  

--- a/addons/sourcemod/scripting/nd_resource_spawner.sp
+++ b/addons/sourcemod/scripting/nd_resource_spawner.sp
@@ -183,18 +183,18 @@ void CheckStableSpawns()
 		if (!tertsSpawned[FIRST_TIER])
 		{
 			// Center map tertiary resource points
-			SpawnTertiaryPoint({-1475.0, 3475.0, -33.0});
-			SpawnTertiaryPoint({-1000.0, -3820.0, -216.0});
-			SpawnTertiaryPoint({1350.0, -2153.0, 20.0});
-			SpawnTertiaryPoint({2495.0, 5775.0, 150.0});
+			SpawnTertiaryPoint({-1475.0, 3475.0, -33.0}, true);
+			SpawnTertiaryPoint({-1000.0, -3820.0, -216.0}, true);
+			SpawnTertiaryPoint({1350.0, -2153.0, 20.0}, true);
+			SpawnTertiaryPoint({2495.0, 5775.0, 150.0}, true);
 			tertsSpawned[FIRST_TIER] = true;
 		}
 		
 		if (RED_OnTeamCount() >= GetSpawnCount(20, 22, 24))
 		{
 			// Base tertiary resource points
-			SpawnTertiaryPoint({987.0, -7562.0, 23.0});  
-			SpawnTertiaryPoint({-1483.0, 9135.0, 123.0});
+			SpawnTertiaryPoint({987.0, -7562.0, 23.0}, true);  
+			SpawnTertiaryPoint({-1483.0, 9135.0, 123.0}, true);
 			tertsSpawned[SECOND_TIER] = true;
 		}
 	}
@@ -223,8 +223,8 @@ void CheckStableSpawns()
 			
 			if (teamCount >= GetSpawnCount(26, 28, 30))
 			{
-				SpawnTertiaryPoint({-5402.0, -3859.0, 74.0});
-				SpawnTertiaryPoint({2340.0, 2558.0, 10.0});
+				SpawnTertiaryPoint({-5402.0, -3859.0, 74.0}, true);
+				SpawnTertiaryPoint({2340.0, 2558.0, 10.0}, true);
 				tertsSpawned[SECOND_TIER] = true;			
 			}
 		}	
@@ -235,28 +235,28 @@ void CheckStableSpawns()
 		if (RED_OnTeamCount() >= cvarClocktowerTertiarySpawns[FIRST_TIER].IntValue || primeDepleted)
 		{
 			// Respawn tunnel resources			
-			SpawnTertiaryPoint({-1674.0, 1201.0, -1848.0});
-			SpawnTertiaryPoint({-2564.0, 282.0, -1672.0});
+			SpawnTertiaryPoint({-1674.0, 1201.0, -1848.0}, true);
+			SpawnTertiaryPoint({-2564.0, 282.0, -1672.0}, true);
 			tertsSpawned[SECOND_TIER] = true;
 		}
 	}
 	
-	else if (ND_CustomMapEquals(map_name, ND_Corner))
+	/*else if (ND_CustomMapEquals(map_name, ND_Corner))
 	{
 		if (RED_OnTeamCount() >= cvarCornerTertiarySpawns.IntValue)
 		{
-			SpawnTertiaryPoint({-3485.0, 11688.0, 5.0});
-			SpawnTertiaryPoint({-1947.0, -1942.0, 7.0});
+			SpawnTertiaryPoint({-3485.0, 11688.0, 5.0}, true);
+			SpawnTertiaryPoint({-1947.0, -1942.0, 7.0}, true);
 			tertsSpawned[SECOND_TIER] = true;		
 		}
-	}
+	}*/
 	
 	else if (ND_StockMapEquals(map_name, ND_Downtown))
 	{
 		if (RED_OnTeamCount() >= GetSpawnCount(26, 28, 30))
 		{
-			SpawnTertiaryPoint({2385.0, -5582.0, -3190.0});
-			SpawnTertiaryPoint({-2668.0, -3169.0, -2829.0});
+			SpawnTertiaryPoint({2385.0, -5582.0, -3190.0}, true);
+			SpawnTertiaryPoint({-2668.0, -3169.0, -2829.0}, true);
 			tertsSpawned[SECOND_TIER] = true;		
 		}
 	}
@@ -284,15 +284,15 @@ void CheckBetaSpawns()
 		{
 			if (!tertsSpawned[FIRST_TIER])
 			{
-				SpawnTertiaryPoint({-5824.0, -32.0, 0.0});
-				SpawnTertiaryPoint({3392.0, 0.0, 5.0});
+				SpawnTertiaryPoint({-5824.0, -32.0, 0.0}, true);
+				SpawnTertiaryPoint({3392.0, 0.0, 5.0}, true);
 				tertsSpawned[FIRST_TIER] = true;
 			}
 			
 			if (teamCount >= cvarGateTertiarySpawns[SECOND_TIER].IntValue)
 			{
-				SpawnTertiaryPoint({-3392.0, -2384.0, 0.0});
-				SpawnTertiaryPoint({-3456.0, 2112.0, -16.0});
+				SpawnTertiaryPoint({-3392.0, -2384.0, 0.0}, true);
+				SpawnTertiaryPoint({-3456.0, 2112.0, -16.0}, true);
 				tertsSpawned[SECOND_TIER] = true;
 			}
 		}
@@ -312,7 +312,7 @@ void AdjustStableSpawns()
 		
 		// Spawn new tertiary near consort base
 		// So empire + consort have same resource acess
-		SpawnTertiaryPoint({1690.0, 4970.0, -1390.0});
+		SpawnTertiaryPoint({1690.0, 4970.0, -1390.0}, false);
 	}
 }
 
@@ -333,7 +333,7 @@ void AdjustBetaSpawns()
 	}
 }
 
-public void SpawnTertiaryPoint(float[VECTOR_SIZE] origin, bool deplete = true)
+public void SpawnTertiaryPoint(float[VECTOR_SIZE] origin, bool deplete)
 {
 	int rt = CreateEntityByName("nd_info_tertiary_resource_point");
 	int trigger = CreateEntityByName("nd_trigger_resource_point");

--- a/addons/sourcemod/scripting/nd_resource_spawner.sp
+++ b/addons/sourcemod/scripting/nd_resource_spawner.sp
@@ -173,8 +173,6 @@ void CheckStableSpawns()
 	char map_name[64];   
 	GetCurrentMap(map_name, sizeof(map_name));
 	
-	bool primeDepleted = ND_PrimeDepleted();
-
 	// Will throw tag mismatch warning, it's okay
 	if (ND_CustomMapEquals(map_name, ND_Submarine))
 	{

--- a/addons/sourcemod/scripting/nd_resource_spawner.sp
+++ b/addons/sourcemod/scripting/nd_resource_spawner.sp
@@ -336,7 +336,7 @@ public void SpawnTertiaryPoint(float[VECTOR_SIZE] origin)
 	int rt = CreateEntityByName("nd_info_tertiary_resource_point");
 	int trigger = CreateEntityByName("nd_trigger_resource_point");
 	
-	bool deplete = RED_ClientCount() >= 12 && ND_PrimeDepleted();
+	bool deplete = ND_GetClientCount() >= 12 && ND_PrimeDepleted();
 	SpawnResourcePoint("tertiary", TERTIARY_MODEL, rt, trigger, origin, deplete);
 }
 

--- a/addons/sourcemod/scripting/nd_resource_spawner.sp
+++ b/addons/sourcemod/scripting/nd_resource_spawner.sp
@@ -173,6 +173,10 @@ void CheckStableSpawns()
 	char map_name[64];   
 	GetCurrentMap(map_name, sizeof(map_name));
 	
+	// Don't deplete some tertaries, if we're depleting prime right away
+	bool primeDepleted = ND_PrimeDepleted();
+	bool deplete = ND_GetClientCount() >= 12 && primeDepleted;
+	
 	// Will throw tag mismatch warning, it's okay
 	if (ND_CustomMapEquals(map_name, ND_Submarine))
 	{
@@ -197,10 +201,10 @@ void CheckStableSpawns()
 	
 	else if (ND_MapEqualsAnyMetro(map_name))
 	{
-		if (RED_OnTeamCount() >= GetSpawnCount(14, 16, 18) || ND_PrimeDepleted())
+		if (RED_OnTeamCount() >= GetSpawnCount(14, 16, 18) || primeDepleted)
 		{
-			SpawnTertiaryPoint({2620.0, 529.0, 5.0});
-			SpawnTertiaryPoint({-2235.0, -3249.0, -85.0});
+			SpawnTertiaryPoint({2620.0, 529.0, 5.0}, deplete);
+			SpawnTertiaryPoint({-2235.0, -3249.0, -85.0}, deplete);
 			tertsSpawned[SECOND_TIER] = true;
 		}
 	}
@@ -208,16 +212,16 @@ void CheckStableSpawns()
 	else if (ND_StockMapEquals(map_name, ND_Silo))
 	{
 		int teamCount = RED_OnTeamCount();
-		if (teamCount >= cvarSiloTertiarySpawns.IntValue)
+		if (teamCount >= cvarSiloTertiarySpawns.IntValue || primeDepleted)
 		{
 			if (!tertsSpawned[FIRST_TIER])
 			{
-				SpawnTertiaryPoint({-3375.0, 1050.0, 2.0});
-				SpawnTertiaryPoint({-36.0, -2000.0, 5.0});
+				SpawnTertiaryPoint({-3375.0, 1050.0, 2.0}, deplete);
+				SpawnTertiaryPoint({-36.0, -2000.0, 5.0}, deplete);
 				tertsSpawned[FIRST_TIER] = true;
 			}
 			
-			if (teamCount >= GetSpawnCount(26, 28, 30) || ND_PrimeDepleted())
+			if (teamCount >= GetSpawnCount(26, 28, 30))
 			{
 				SpawnTertiaryPoint({-5402.0, -3859.0, 74.0});
 				SpawnTertiaryPoint({2340.0, 2558.0, 10.0});
@@ -228,7 +232,7 @@ void CheckStableSpawns()
 	
 	else if (ND_StockMapEquals(map_name, ND_Clocktower))
 	{
-		if (RED_OnTeamCount() >= cvarClocktowerTertiarySpawns[FIRST_TIER].IntValue || ND_PrimeDepleted())
+		if (RED_OnTeamCount() >= cvarClocktowerTertiarySpawns[FIRST_TIER].IntValue || primeDepleted)
 		{
 			// Respawn tunnel resources			
 			SpawnTertiaryPoint({-1674.0, 1201.0, -1848.0});
@@ -259,10 +263,10 @@ void CheckStableSpawns()
 	
 	else if (ND_StockMapEquals(map_name, ND_Hydro))
 	{
-		if (RED_OnTeamCount() >= GetSpawnCount(26, 28, 28) || ND_PrimeDepleted())
+		if (RED_OnTeamCount() >= GetSpawnCount(26, 28, 28) || primeDepleted)
 		{
-			SpawnTertiaryPoint({2132.0, 2559.0, 18.0});
-			SpawnTertiaryPoint({-5199.0, -3461.0, 191.0});
+			SpawnTertiaryPoint({2132.0, 2559.0, 18.0}, deplete);
+			SpawnTertiaryPoint({-5199.0, -3461.0, 191.0}, deplete);
 			tertsSpawned[SECOND_TIER] = true;	
 		}
 	}
@@ -329,13 +333,13 @@ void AdjustBetaSpawns()
 	}
 }
 
-public void SpawnTertiaryPoint(float[VECTOR_SIZE] origin)
+public void SpawnTertiaryPoint(float[VECTOR_SIZE] origin, bool deplete = true)
 {
 	int rt = CreateEntityByName("nd_info_tertiary_resource_point");
 	int trigger = CreateEntityByName("nd_trigger_resource_point");
 	
-	bool deplete = ND_GetClientCount() >= 12 && ND_PrimeDepleted();
-	SpawnResourcePoint("tertiary", TERTIARY_MODEL, rt, trigger, origin, deplete);
+	bool depleteTert = deplete && ND_PrimeDepleted();
+	SpawnResourcePoint("tertiary", TERTIARY_MODEL, rt, trigger, origin, depleteTert);
 }
 
 public void SpawnResourcePoint( const char[] type, const char[] model, int rt, int trigger, float[VECTOR_SIZE] origin, bool deplete)

--- a/addons/sourcemod/scripting/nd_resource_spawner.sp
+++ b/addons/sourcemod/scripting/nd_resource_spawner.sp
@@ -38,14 +38,12 @@ bool tertsSpawned[2] = { false, ... };
 
 /* Plugin Convars */
 ConVar cvarMarsTertiarySpawns;
-ConVar cvarMetroTertiarySpawns;
 ConVar cvarOasisTertiarySpawns;
 ConVar cvarCoastTertiarySpawns;
 ConVar cvarCornerTertiarySpawns;
 ConVar cvarNuclearTertiarySpawns;
-ConVar cvarDowntownTertiarySpawns;
 ConVar cvarRoadworkTertiarySpawns;
-ConVar cvarSiloTertiarySpawns[2];
+ConVar cvarSiloTertiarySpawns;
 ConVar cvarGateTertiarySpawns[2];
 ConVar cvarRockTertiarySpawns[2];
 ConVar cvarOilfeildTertiarySpawns[2];
@@ -106,15 +104,12 @@ void CreateMapConvars()
 	
 	// Create convars for resoruce spawning on a per map basis
 	cvarMarsTertiarySpawns = AutoExecConfig_CreateConVar("sm_tertiary_mars", "16", "Sets number of players to spawn extra tertaries on mars.");
-	cvarMetroTertiarySpawns = AutoExecConfig_CreateConVar("sm_tertiary_metro", "18", "Sets number of players to spawn extra tertaries on metro.");	
 	cvarOasisTertiarySpawns = AutoExecConfig_CreateConVar("sm_tertiary_oasis", "18", "Sets number of players to spawn extra tertaries on oasis.");
 	cvarCoastTertiarySpawns = AutoExecConfig_CreateConVar("sm_tertiary_coast", "16", "Sets number of players to spawn extra tertaries on coast.");	
 	cvarCornerTertiarySpawns = AutoExecConfig_CreateConVar("sm_tertiary_corner", "20", "Sets number of players to spawn extra tertaries on corner.");
 	cvarNuclearTertiarySpawns = AutoExecConfig_CreateConVar("sm_tertiary_nuclear", "14", "Sets number of players to spawn extra tertaries on nuclear.");
-	cvarDowntownTertiarySpawns = AutoExecConfig_CreateConVar("sm_tertiary_downtown", "28", "Sets number of players to spawn extra tertaries on downtown and downtown_dyn.");
 	cvarRoadworkTertiarySpawns = AutoExecConfig_CreateConVar("sm_tertiary_roadwork", "16", "Sets number of players to spawn extra tertaries on roadwork.");
-	cvarSiloTertiarySpawns[FIRST_TIER] = AutoExecConfig_CreateConVar("sm_tertiary_silo1", "14", "Sets number of players to spawn extra tertaries on silo.");
-	cvarSiloTertiarySpawns[SECOND_TIER] = AutoExecConfig_CreateConVar("sm_tertiary_silo2", "26", "Sets number of players to spawn extra tertaries on silo.");	
+	cvarSiloTertiarySpawns = AutoExecConfig_CreateConVar("sm_tertiary_silo1", "14", "Sets number of players to spawn extra tertaries on silo.");
 	cvarGateTertiarySpawns[FIRST_TIER] = AutoExecConfig_CreateConVar("sm_tertiary_gate1", "16", "Sets number of players to spawn extra tertaries on gate.");
 	cvarGateTertiarySpawns[SECOND_TIER] = AutoExecConfig_CreateConVar("sm_tertiary_gate2", "22", "Sets number of players to spawn extra tertaries on gate.");
 	cvarRockTertiarySpawns[FIRST_TIER] = AutoExecConfig_CreateConVar("sm_tertiary_rock1", "8", "Sets number of players to spawn extra tertaries on rock.");
@@ -177,6 +172,8 @@ void CheckStableSpawns()
 {
 	char map_name[64];   
 	GetCurrentMap(map_name, sizeof(map_name));
+	
+	bool primeDepleted = ND_PrimeDepleted();
 
 	// Will throw tag mismatch warning, it's okay
 	if (ND_CustomMapEquals(map_name, ND_Submarine))
@@ -213,7 +210,7 @@ void CheckStableSpawns()
 	else if (ND_StockMapEquals(map_name, ND_Silo))
 	{
 		int teamCount = RED_OnTeamCount();
-		if (teamCount >= cvarSiloTertiarySpawns[FIRST_TIER].IntValue)
+		if (teamCount >= cvarSiloTertiarySpawns.IntValue)
 		{
 			if (!tertsSpawned[FIRST_TIER])
 			{
@@ -338,11 +335,12 @@ public void SpawnTertiaryPoint(float[VECTOR_SIZE] origin)
 {
 	int rt = CreateEntityByName("nd_info_tertiary_resource_point");
 	int trigger = CreateEntityByName("nd_trigger_resource_point");
-       
-	SpawnResourcePoint("tertiary", TERTIARY_MODEL, rt, trigger, origin);
+	
+	bool deplete = RED_ClientCount() >= 12 && ND_PrimeDepleted();
+	SpawnResourcePoint("tertiary", TERTIARY_MODEL, rt, trigger, origin, deplete);
 }
 
-public void SpawnResourcePoint( const char[] type, const char[] model, int rt, int trigger, float[VECTOR_SIZE] origin)
+public void SpawnResourcePoint( const char[] type, const char[] model, int rt, int trigger, float[VECTOR_SIZE] origin, bool deplete)
 {	
 	char rt_name[32];
 	char trigger_name[32];
@@ -364,8 +362,7 @@ public void SpawnResourcePoint( const char[] type, const char[] model, int rt, i
 	SetEntProp(trigger, Prop_Data, "m_iButtonsToCap", 0);
 	SetEntProp(trigger, Prop_Data, "m_iNumPlayersToCap", 1);
 	
-	// If prime is depleted, also deplete the tertiary resource point
-	if (ND_PrimeDepleted())
+	if (deplete)
 		SetEntProp(rt, Prop_Send, "m_iCurrentResources", 0);
        
 	SetEntProp(trigger, Prop_Send, "m_nSolidType", 2);


### PR DESCRIPTION
- Deplete tertiary on spawn if prime is depleted.

- Don't always deplete with less than 12 players. We're going to deplete prime instead.

- Cleanup Convars

