### PR TITLE
Fixes communication to commander

### DIFF
--- a/addons/sourcemod/scripting/nd_build_restrict.sp
+++ b/addons/sourcemod/scripting/nd_build_restrict.sp
@@ -74,7 +74,7 @@ public Action ND_OnCommanderBuildStructure(int client, ND_Structures &structure,
 		int team = GetClientTeam(client);
 		if (!ND_ItemHasBeenResearched(team, Advanced_Manufacturing) && ND_GetMGTurretCount(team) > cvarMGTurrentMax.IntValue)
 		{
-			PrintToChat(client, "[RS] MG Torrent limit researched. Advanced Manufacturing research required.");
+			UTIL_Commander_FailureText(client, "MAXED MG TURRETS IN EARLY GAME");
 			return Plugin_Stop;
 		}	
 	}


### PR DESCRIPTION
Uses consistent in-game communication to commander as other errors - provides an audible indicator with a denied sound as well as utilizes the commander-specific error field for more accessible messaging to the commander